### PR TITLE
Adds constructor props to BoundCluster

### DIFF
--- a/lib/BoundCluster.js
+++ b/lib/BoundCluster.js
@@ -3,16 +3,17 @@ const {getPropertyDescriptor} = require('./util');
 
 class BoundCluster {
 
-    constructor() {
+    constructor(props = {}) {
         this.clusterRevision = 1;
+        this.props = props;
     }
 
     async handleFrame(frame, meta, rawFrame) {
         const commands = this.cluster.commandsById[frame.cmdId] || [];
 
         const command = commands
-            .filter(cmd => 
-                frame.frameControl.clusterSpecific === !cmd.global 
+            .filter(cmd =>
+                frame.frameControl.clusterSpecific === !cmd.global
                 && (cmd.global || frame.frameControl.manufacturerSpecific === !!cmd.manufacturerId)
                 && (cmd.global || !frame.frameControl.manufacturerSpecific || frame.manufacturerId === cmd.manufacturerId)
             )
@@ -20,7 +21,7 @@ class BoundCluster {
             .pop();
 
         if(command) {
-            const args = command.args ? 
+            const args = command.args ?
                 command.args.fromBuffer(frame.data, 0)
                 : undefined;
 
@@ -55,7 +56,7 @@ class BoundCluster {
             } catch(e) {
                 console.log('Failed to parse attribute:', attr ? attr.name || aId : aId, e.message);
             }
-            
+
             return {
                 id: aId,
                 status: 'FAILURE',
@@ -90,7 +91,7 @@ class BoundCluster {
             } catch(e) {
                 console.log('Failed to parse attribute:', attr ? attr.name || attrValue.id : attrValue.id, e.message);
             }
-            
+
             return {
                 id: attrValue.id,
                 status: 'FAILURE',
@@ -217,7 +218,7 @@ class BoundCluster {
             }),
         };
     }
- 
+
 };
 
 module.exports = BoundCluster;


### PR DESCRIPTION
This allows passing props to a BoundCluster instance which can be accessed from within the instance:

```javascript
class Example extends BoundCluster() {
    onCommand() {
        this.props.externalFunction();
    }
}

const example = new Example({externalFunction: () => {}});
```

We want to avoid collisions, therefore the constructor arguments are placed on `this.props`.