### PR TITLE
feat: consistent api and jsdoc

### DIFF
--- a/lib/BoundCluster.js
+++ b/lib/BoundCluster.js
@@ -37,7 +37,7 @@ class BoundCluster {
    * to the controller. It assembles attribute values by reading `this[attr.name]` for all
    * supported attributes of this cluster and sends the response to the remote node.
    * @param {object} options
-   * @param {object[]} options.attributes
+   * @param {string[]} options.attributes
    * @returns {Promise<{attributes: Buffer}>}
    */
   async readAttributes({ attributes }) {


### PR DESCRIPTION
https://github.com/athombv/node-zigbee-clusters/pull/24#discussion_r408091636
In this comment I didn't know what to write so I ended up writing nothing...
What I intended is
> I'm not sure but there are multiple places with this JSDoc and I think it should be this.

Since you applied the suggestion I'm assuming that the change is correct?
Here I updated all remaining jsdoc to use the same syntax.

In addition I tried to make all methods have the same API but i'm not sure whether that makes sense