### PR TITLE
fix: add conditional manufacturerId to global commands

### DIFF
--- a/lib/Cluster.js
+++ b/lib/Cluster.js
@@ -363,6 +363,7 @@ class Cluster extends EventEmitter {
 
   /**
    * Command which reads a given set of attributes from the remote cluster.
+   * Note: do not mix regular and manufacturer specific attributes.
    * @param {string[]} attributeNames
    * @returns {Promise<{}>} - Object with attribute values (e.g. `{ onOff: true }`)
    */
@@ -383,8 +384,14 @@ class Cluster extends EventEmitter {
 
     const resultObj = {};
     while (attrIds.size) {
-      debug(this.constructor.NAME, 'read attributes', [...attrIds]);
-      const { attributes } = await super.readAttributes({ attributes: [...attrIds] });
+      // Check if command should get manufacturerSpecific flag
+      const manufacturerId = this._checkForManufacturerSpecificAttributes(Array.from(attrIds));
+      debug(this.constructor.NAME, 'read attributes', [...attrIds], manufacturerId ? `manufacturer specific id ${manufacturerId}` : '');
+
+      const readAttributesOptions = { attributes: [...attrIds] };
+      if (manufacturerId) readAttributesOptions.manufacturerId = manufacturerId;
+      const { attributes } = await super.readAttributes(readAttributesOptions);
+
       debug(this.constructor.NAME, 'read attributes result', { attributes });
       const result = this.constructor.attributeArrayStatusDataType.fromBuffer(attributes, 0);
       if (!result.length) break;
@@ -402,10 +409,9 @@ class Cluster extends EventEmitter {
 
   /**
    * Command which writes a given set of attribute key-value pairs to the remote cluster.
+   * Note: do not mix regular and manufacturer specific attributes.
    * @param {object} attributes - Object with attribute names as keys and their values (e.g. `{
    * onOff: true, fakeAttributeName: 10 }`.
-   *
-   * TODO: needs to be tested with a device that supports a attribute write
    * @returns {Promise<*|{attributes: *}>}
    */
   async writeAttributes(attributes = {}) {
@@ -420,15 +426,27 @@ class Cluster extends EventEmitter {
       };
     });
 
+    // Check if command should get manufacturerSpecific flag
+    const manufacturerId = this._checkForManufacturerSpecificAttributes(
+      Object.keys(attributes).map(n => {
+        const attr = this.constructor.attributes[n];
+        return attr.id;
+      }),
+    );
+
     let data = Buffer.alloc(1024);
     data = data.slice(0, this.constructor.attributeArrayDataType.toBuffer(data, arr, 0));
 
-    debug(this.constructor.NAME, 'write attributes', attributes);
-    return super.writeAttributes({ attributes: data });
+    debug(this.constructor.NAME, 'write attributes', attributes, manufacturerId ? `manufacturer specific id ${manufacturerId}` : '');
+
+    const writeAttributeOptions = { attributes: data };
+    if (manufacturerId) writeAttributeOptions.manufacturerId = manufacturerId;
+    return super.writeAttributes(writeAttributeOptions);
   }
 
   /**
    * Command which configures attribute reporting for the given `attributes` on the remote cluster.
+   * Note: do not mix regular and manufacturer specific attributes.
    * @param {object} attributes - Attribute reporting configuration (e.g. `{ onOff: {
    * minInterval: 0, maxInterval: 300, minChange: 1 } }`)
    * @returns {Promise<void>}
@@ -463,8 +481,20 @@ class Cluster extends EventEmitter {
       req.push(config);
     }
     if (req.length) {
-      debug(this.constructor.NAME, 'configure reporting', req);
-      const { reports } = await super.configureReporting({ reports: req });
+      // Check if command should get manufacturerSpecific flag
+      const manufacturerId = this._checkForManufacturerSpecificAttributes(
+        Object.keys(attributes).map(n => {
+          const attr = this.constructor.attributes[n];
+          return attr.id;
+        }),
+      );
+
+      debug(this.constructor.NAME, 'configure reporting', req, manufacturerId ? `manufacturer specific id ${manufacturerId}` : '');
+
+      const configureReportingOptions = { reports: req };
+      if (manufacturerId) configureReportingOptions.manufacturerId = manufacturerId;
+      const { reports } = await super.configureReporting(configureReportingOptions);
+
       debug(this.constructor.NAME, 'configured reporting', reports);
       for (const result of reports) {
         if (result.status !== 'SUCCESS') {
@@ -491,6 +521,7 @@ class Cluster extends EventEmitter {
    * remote cluster. Currently this only takes the 'reported' into account, this represents the
    * reports the remote cluster would sent out, instead of receive (which is likely the most
    * interesting).
+   * Note: do not mix regular and manufacturer specific attributes.
    * @param {Array} attributes - Array with number/strings (either attribute id, or attribute name).
    * @returns {Promise<ReadReportingConfiguration[]>} - Returns array with
    * ReadReportingConfiguration objects per attribute.
@@ -522,12 +553,21 @@ class Cluster extends EventEmitter {
       });
     }
 
-    debug(this.constructor.NAME, 'read reporting configuration', req);
+    // Check if command should get manufacturerSpecific flag
+    const manufacturerId = this._checkForManufacturerSpecificAttributes(
+      attributes
+        .map(attributeName => this.constructor.attributes[attributeName].id),
+    );
+
+    debug(this.constructor.NAME, 'read reporting configuration', req, manufacturerId ? `manufacturer specific id ${manufacturerId}` : '');
 
     // If a request has been constructed execute it
     if (req.length) {
+      const readReportingConfigurationOptions = { attributes: req };
+      if (manufacturerId) readReportingConfigurationOptions.manufacturerId = manufacturerId;
+
       // Perform request, it returns a buffer that needs to be parsed
-      const { reports } = await super.readReportingConfiguration({ attributes: req });
+      const { reports } = await super.readReportingConfiguration(readReportingConfigurationOptions);
       debug(this.constructor.NAME, 'read reporting configuration result', reports);
 
       // Return the parsed reports
@@ -949,6 +989,15 @@ class Cluster extends EventEmitter {
 
             if (cmd.global) {
               payload.frameControl = [];
+
+              // Some global commands can also be manufacturerSpecific (e.g. read/write manuf
+              // specific attributes), in that case the manuf id needs to be parsed from the
+              // args as it is a dynamic property which can not be defined on the command.
+              if (typeof args.manufacturerId === 'number') {
+                payload.frameControl.push('manufacturerSpecific');
+                payload.manufacturerId = args.manufacturerId;
+                delete args.manufacturerId;
+              }
             }
 
             if (cmd.manufacturerId) {
@@ -987,6 +1036,42 @@ class Cluster extends EventEmitter {
         }[cmdName],
       });
     }
+  }
+
+  /**
+   * Given an array of attribute ids it checks if all of the attributes are manufacturer
+   * specific attributes. If that is the case it will return the manufacturerId so that the
+   * command can set the manufacturerSpecific flag.
+   * @param {number[]} attributeIds
+   * @returns {null|number}
+   * @private
+   */
+  _checkForManufacturerSpecificAttributes(attributeIds) {
+    // Convert to set
+    const attrIdsSet = new Set(attributeIds);
+
+    // Filter attributeIds for manufacturer specific attributes
+    const manufacturerIds = Object.entries(this.constructor.attributes)
+      .reduce((acc, [key, value]) => {
+        if (attrIdsSet.has(value.id) && typeof value.manufacturerId === 'number') acc.push(value.manufacturerId);
+        return acc;
+      }, []);
+
+    // Do not allow different manufacturer ids in one command
+    if (new Set(manufacturerIds).size > 1) {
+      throw new Error('Error: detected multiple manufacturer ids, can only read from one at a'
+        + ' time');
+    }
+
+    // Show warning if a manufacturer specific attribute was found amongst non-manufacturer
+    // specific attributes
+    if (manufacturerIds.length > 0 && attrIdsSet.size !== manufacturerIds.length) {
+      debug(this.constructor.NAME, 'WARNING expected only manufacturer specific attributes got:', manufacturerIds);
+    }
+
+    // Return the manufacturerId that was found in the attributes
+    if (attrIdsSet.size === manufacturerIds.length) return manufacturerIds[0];
+    return null;
   }
 
 }

--- a/lib/Cluster.js
+++ b/lib/Cluster.js
@@ -900,7 +900,6 @@ class Cluster extends EventEmitter {
       ZCLAttributeDataRecord(false, clusterClass.attributesById),
     );
 
-
     // Ids are not unique
     clusterClass.commandsById = Object.entries(clusterClass.commands).reduce((r, [name, _cmd]) => {
       const cmd = { ..._cmd, name };
@@ -936,7 +935,6 @@ class Cluster extends EventEmitter {
 
       return r;
     }, {});
-
 
     // eslint-disable-next-line guard-for-in,no-restricted-syntax
     for (const cmdName in commands) {

--- a/lib/Cluster.js
+++ b/lib/Cluster.js
@@ -308,9 +308,15 @@ class Cluster extends EventEmitter {
    * commands are commands which may be sent by the remote cluster.
    *
    * TODO: handle the case where `lastResponse===false`. It might be possible that there are
-   * more commands to be reported than can be transmitted in one report (in practice very
-   * unlikely though). If `lastResponse===false` invoke `discoverCommandsGenerated` again
-   * starting from the index where the previous invocation stopped (`maxResults`).
+   *  more commands to be reported than can be transmitted in one report (in practice very
+   *  unlikely though). If `lastResponse===false` invoke `discoverCommandsGenerated` again
+   *  starting from the index where the previous invocation stopped (`maxResults`).
+   *
+   * TODO: The manufacturer-specific sub-field SHALL be set to 0 to discover standard commands
+   *  in a ZigBee cluster or 1 to discover manufacturer-specific commands in either a standard or
+   *  a manufacturer-specific cluster. A manufacturer ID in this field of 0xffff (wildcard) will
+   *  discover any manufacture- specific
+   *  commands.
    *
    * @param {number} [startValue=0]
    * @param {number} [maxResults=250]
@@ -337,9 +343,14 @@ class Cluster extends EventEmitter {
    * commands are commands which may be received by the remote cluster.
    *
    * TODO: handle the case where `lastResponse===false`. It might be possible that there are
-   * more commands to be reported than can be transmitted in one report (in practice very
-   * unlikely though). If `lastResponse===false` invoke `discoverCommandsGenerated` again
-   * starting from the index where the previous invocation stopped (`maxResults`).
+   *  more commands to be reported than can be transmitted in one report (in practice very
+   *  unlikely though). If `lastResponse===false` invoke `discoverCommandsGenerated` again
+   *  starting from the index where the previous invocation stopped (`maxResults`).
+   *
+   * TODO: The manufacturer-specific sub-field SHALL be set to 0 to discover standard commands
+   *  in a ZigBee cluster or 1 to discover manufacturer-specific commands in either a standard or
+   *  a manufacturer-specific cluster. A manufacturer ID in this field of 0xffff (wildcard) will
+   *  discover any manufacture- specific commands.
    *
    * @param {number} [startValue=0]
    * @param {number} [maxResults=250]
@@ -582,9 +593,13 @@ class Cluster extends EventEmitter {
    * Command which discovers the implemented attributes on the remote cluster.
    *
    * TODO: handle the case where `lastResponse===false`. It might be possible that there are
-   * more commands to be reported than can be transmitted in one report (in practice very
-   * unlikely though). If `lastResponse===false` invoke `discoverCommandsGenerated` again
-   * starting from the index where the previous invocation stopped (`maxResults`).
+   *  more commands to be reported than can be transmitted in one report (in practice very
+   *  unlikely though). If `lastResponse===false` invoke `discoverCommandsGenerated` again
+   *  starting from the index where the previous invocation stopped (`maxResults`).
+   *
+   * TODO: The manufacturer specific sub-field SHALL be set to 0 to discover standard attributes
+   *  in a ZigBee cluster or 1 to discover manufacturer specific attributes in either a standard
+   *  or a manufacturer specific cluster.
    *
    * @returns {Promise<Array>} - Array with string or number values (depending on if the
    * attribute
@@ -613,9 +628,14 @@ class Cluster extends EventEmitter {
    * attribute (whether it is readable/writable/reportable).
    *
    * TODO: handle the case where `lastResponse===false`. It might be possible that there are
-   * more commands to be reported than can be transmitted in one report (in practice very
-   * unlikely though). If `lastResponse===false` invoke `discoverCommandsGenerated` again
-   * starting from the index where the previous invocation stopped (`maxResults`).
+   *  more commands to be reported than can be transmitted in one report (in practice very
+   *  unlikely though). If `lastResponse===false` invoke `discoverCommandsGenerated` again
+   *  starting from the index where the previous invocation stopped (`maxResults`).
+   *
+   * TODO: The manufacturer-specific sub-field SHALL be set to 0 to discover standard attributes
+   *  in a ZigBee cluster or 1 to discover manufacturer-specific attributes in either a standard
+   *  or a manufacturer- specific cluster. A manufacturer ID in this field of 0xffff (wildcard)
+   *  will discover any manufacture-specific attributes.
    *
    * @returns {Promise<Array>} - Returns an array with objects with attribute names as keys and
    * following object as values: `{name: string, id: number, acl: { readable: boolean, writable:

--- a/lib/Cluster.js
+++ b/lib/Cluster.js
@@ -399,9 +399,10 @@ class Cluster extends EventEmitter {
       const manufacturerId = this._checkForManufacturerSpecificAttributes(Array.from(attrIds));
       debug(this.constructor.NAME, 'read attributes', [...attrIds], manufacturerId ? `manufacturer specific id ${manufacturerId}` : '');
 
-      const readAttributesOptions = { attributes: [...attrIds] };
-      if (manufacturerId) readAttributesOptions.manufacturerId = manufacturerId;
-      const { attributes } = await super.readAttributes(readAttributesOptions);
+      const { attributes } = await super.readAttributes({
+        attributes: [...attrIds],
+        manufacturerId,
+      });
 
       debug(this.constructor.NAME, 'read attributes result', { attributes });
       const result = this.constructor.attributeArrayStatusDataType.fromBuffer(attributes, 0);
@@ -450,9 +451,7 @@ class Cluster extends EventEmitter {
 
     debug(this.constructor.NAME, 'write attributes', attributes, manufacturerId ? `manufacturer specific id ${manufacturerId}` : '');
 
-    const writeAttributeOptions = { attributes: data };
-    if (manufacturerId) writeAttributeOptions.manufacturerId = manufacturerId;
-    return super.writeAttributes(writeAttributeOptions);
+    return super.writeAttributes({ attributes: data, manufacturerId });
   }
 
   /**
@@ -502,9 +501,7 @@ class Cluster extends EventEmitter {
 
       debug(this.constructor.NAME, 'configure reporting', req, manufacturerId ? `manufacturer specific id ${manufacturerId}` : '');
 
-      const configureReportingOptions = { reports: req };
-      if (manufacturerId) configureReportingOptions.manufacturerId = manufacturerId;
-      const { reports } = await super.configureReporting(configureReportingOptions);
+      const { reports } = await super.configureReporting({ reports: req, manufacturerId });
 
       debug(this.constructor.NAME, 'configured reporting', reports);
       for (const result of reports) {
@@ -574,11 +571,11 @@ class Cluster extends EventEmitter {
 
     // If a request has been constructed execute it
     if (req.length) {
-      const readReportingConfigurationOptions = { attributes: req };
-      if (manufacturerId) readReportingConfigurationOptions.manufacturerId = manufacturerId;
-
       // Perform request, it returns a buffer that needs to be parsed
-      const { reports } = await super.readReportingConfiguration(readReportingConfigurationOptions);
+      const { reports } = await super.readReportingConfiguration({
+        attributes: req,
+        manufacturerId,
+      });
       debug(this.constructor.NAME, 'read reporting configuration result', reports);
 
       // Return the parsed reports
@@ -1013,9 +1010,12 @@ class Cluster extends EventEmitter {
               // Some global commands can also be manufacturerSpecific (e.g. read/write manuf
               // specific attributes), in that case the manuf id needs to be parsed from the
               // args as it is a dynamic property which can not be defined on the command.
-              if (typeof args.manufacturerId === 'number') {
-                payload.frameControl.push('manufacturerSpecific');
-                payload.manufacturerId = args.manufacturerId;
+              if (args.manufacturerId !== undefined) {
+                if (typeof args.manufacturerId === 'number') {
+                  payload.frameControl.push('manufacturerSpecific');
+                  payload.manufacturerId = args.manufacturerId;
+                }
+                // Always delete it as it is not part of the command args
                 delete args.manufacturerId;
               }
             }

--- a/lib/Cluster.js
+++ b/lib/Cluster.js
@@ -440,10 +440,7 @@ class Cluster extends EventEmitter {
 
     // Check if command should get manufacturerSpecific flag
     const manufacturerId = this._checkForManufacturerSpecificAttributes(
-      Object.keys(attributes).map(n => {
-        const attr = this.constructor.attributes[n];
-        return attr.id;
-      }),
+      Object.keys(attributes).map(n => this.constructor.attributes[n].id),
     );
 
     let data = Buffer.alloc(1024);
@@ -493,10 +490,7 @@ class Cluster extends EventEmitter {
     if (req.length) {
       // Check if command should get manufacturerSpecific flag
       const manufacturerId = this._checkForManufacturerSpecificAttributes(
-        Object.keys(attributes).map(n => {
-          const attr = this.constructor.attributes[n];
-          return attr.id;
-        }),
+        Object.keys(attributes).map(n => this.constructor.attributes[n].id),
       );
 
       debug(this.constructor.NAME, 'configure reporting', req, manufacturerId ? `manufacturer specific id ${manufacturerId}` : '');
@@ -1071,16 +1065,16 @@ class Cluster extends EventEmitter {
     const attrIdsSet = new Set(attributeIds);
 
     // Filter attributeIds for manufacturer specific attributes
-    const manufacturerIds = Object.entries(this.constructor.attributes)
-      .reduce((acc, [key, value]) => {
-        if (attrIdsSet.has(value.id) && typeof value.manufacturerId === 'number') acc.push(value.manufacturerId);
-        return acc;
-      }, []);
+    const manufacturerIds = [];
+    for (const attribute of Object.values(this.constructor.attributes)) {
+      if (attrIdsSet.has(attribute.id) && typeof attribute.manufacturerId === 'number') {
+        manufacturerIds.push(attribute.manufacturerId);
+      }
+    }
 
     // Do not allow different manufacturer ids in one command
     if (new Set(manufacturerIds).size > 1) {
-      throw new Error('Error: detected multiple manufacturer ids, can only read from one at a'
-        + ' time');
+      throw new Error('Error: detected multiple manufacturer ids, can only read from one at a time');
     }
 
     // Show warning if a manufacturer specific attribute was found amongst non-manufacturer

--- a/package-lock.json
+++ b/package-lock.json
@@ -19,44 +19,44 @@
       }
     },
     "@babel/generator": {
-      "version": "7.9.5",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.5.tgz",
-      "integrity": "sha512-GbNIxVB3ZJe3tLeDm1HSn2AhuD/mVcyLDpgtLXa5tplmWrJdF/elxB56XNqCuD6szyNkDi6wuoKXln3QeBmCHQ==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.4.tgz",
+      "integrity": "sha512-toLIHUIAgcQygFZRAQcsLQV3CBuX6yOIru1kJk/qqqvcRmZrYe6WavZTSG+bB8MxhnL9YPf+pKQfuiP161q7ng==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.9.5",
+        "@babel/types": "^7.10.4",
         "jsesc": "^2.5.1",
         "lodash": "^4.17.13",
         "source-map": "^0.5.0"
       }
     },
     "@babel/helper-function-name": {
-      "version": "7.9.5",
-      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
-      "integrity": "sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.4.tgz",
+      "integrity": "sha512-YdaSyz1n8gY44EmN7x44zBn9zQ1Ry2Y+3GTA+3vH6Mizke1Vw0aWDM66FOYEPw8//qKkmqOckrGgTYa+6sceqQ==",
       "dev": true,
       "requires": {
-        "@babel/helper-get-function-arity": "^7.8.3",
-        "@babel/template": "^7.8.3",
-        "@babel/types": "^7.9.5"
+        "@babel/helper-get-function-arity": "^7.10.4",
+        "@babel/template": "^7.10.4",
+        "@babel/types": "^7.10.4"
       }
     },
     "@babel/helper-get-function-arity": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
-      "integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.4.tgz",
+      "integrity": "sha512-EkN3YDB+SRDgiIUnNgcmiD361ti+AVbL3f3Henf6dqqUyr5dMsorno0lJWJuLhDhkI5sYEpgj6y9kB8AOU1I2A==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.8.3"
+        "@babel/types": "^7.10.4"
       }
     },
     "@babel/helper-split-export-declaration": {
-      "version": "7.8.3",
-      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
-      "integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.4.tgz",
+      "integrity": "sha512-pySBTeoUff56fL5CBU2hWm9TesA4r/rOkI9DyJLvvgz09MB9YtfIYe3iBriVaYNaPe+Alua0vBIOVOLs2buWhg==",
       "dev": true,
       "requires": {
-        "@babel/types": "^7.8.3"
+        "@babel/types": "^7.10.4"
       }
     },
     "@babel/helper-validator-identifier": {
@@ -83,33 +83,99 @@
       "dev": true
     },
     "@babel/template": {
-      "version": "7.8.6",
-      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
-      "integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.4.tgz",
+      "integrity": "sha512-ZCjD27cGJFUB6nmCB1Enki3r+L5kJveX9pq1SvAUKoICy6CZ9yD8xO086YXdYhvNjBdnekm4ZnaP5yC8Cs/1tA==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.8.3",
-        "@babel/parser": "^7.8.6",
-        "@babel/types": "^7.8.6"
+        "@babel/code-frame": "^7.10.4",
+        "@babel/parser": "^7.10.4",
+        "@babel/types": "^7.10.4"
+      },
+      "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+          "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.10.4"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+          "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+          "dev": true
+        },
+        "@babel/highlight": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+          "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.4",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.4.tgz",
+          "integrity": "sha512-8jHII4hf+YVDsskTF6WuMB3X4Eh+PsUkC2ljq22so5rHvH+T8BzyL94VOdyFLNR8tBSVXOTbNHOKpR4TfRxVtA==",
+          "dev": true
+        }
       }
     },
     "@babel/traverse": {
-      "version": "7.9.5",
-      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.5.tgz",
-      "integrity": "sha512-c4gH3jsvSuGUezlP6rzSJ6jf8fYjLj3hsMZRx/nX0h+fmHN0w+ekubRrHPqnMec0meycA2nwCsJ7dC8IPem2FQ==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.4.tgz",
+      "integrity": "sha512-aSy7p5THgSYm4YyxNGz6jZpXf+Ok40QF3aA2LyIONkDHpAcJzDUqlCKXv6peqYUs2gmic849C/t2HKw2a2K20Q==",
       "dev": true,
       "requires": {
-        "@babel/code-frame": "^7.8.3",
-        "@babel/generator": "^7.9.5",
-        "@babel/helper-function-name": "^7.9.5",
-        "@babel/helper-split-export-declaration": "^7.8.3",
-        "@babel/parser": "^7.9.0",
-        "@babel/types": "^7.9.5",
+        "@babel/code-frame": "^7.10.4",
+        "@babel/generator": "^7.10.4",
+        "@babel/helper-function-name": "^7.10.4",
+        "@babel/helper-split-export-declaration": "^7.10.4",
+        "@babel/parser": "^7.10.4",
+        "@babel/types": "^7.10.4",
         "debug": "^4.1.0",
         "globals": "^11.1.0",
         "lodash": "^4.17.13"
       },
       "dependencies": {
+        "@babel/code-frame": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.4.tgz",
+          "integrity": "sha512-vG6SvB6oYEhvgisZNFRmRCUkLz11c7rp+tbNTynGqc6mS1d5ATd/sGyV6W0KZZnXRKMTzZDRgQT3Ou9jhpAfUg==",
+          "dev": true,
+          "requires": {
+            "@babel/highlight": "^7.10.4"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+          "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+          "dev": true
+        },
+        "@babel/highlight": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.4.tgz",
+          "integrity": "sha512-i6rgnR/YgPEQzZZnbTHHuZdlE8qyoBNalD6F+q4vAFlcMEcqmkoG+mPqJYJCo63qPf74+Y1UZsl3l6f7/RIkmA==",
+          "dev": true,
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.10.4",
+            "chalk": "^2.0.0",
+            "js-tokens": "^4.0.0"
+          }
+        },
+        "@babel/parser": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.4.tgz",
+          "integrity": "sha512-8jHII4hf+YVDsskTF6WuMB3X4Eh+PsUkC2ljq22so5rHvH+T8BzyL94VOdyFLNR8tBSVXOTbNHOKpR4TfRxVtA==",
+          "dev": true
+        },
         "globals": {
           "version": "11.12.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
@@ -119,20 +185,34 @@
       }
     },
     "@babel/types": {
-      "version": "7.9.5",
-      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
-      "integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
+      "version": "7.10.4",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.4.tgz",
+      "integrity": "sha512-UTCFOxC3FsFHb7lkRMVvgLzaRVamXuAs2Tz4wajva4WxtVY82eZeaUBtC2Zt95FU9TiznuC0Zk35tsim8jeVpg==",
       "dev": true,
       "requires": {
-        "@babel/helper-validator-identifier": "^7.9.5",
+        "@babel/helper-validator-identifier": "^7.10.4",
         "lodash": "^4.17.13",
         "to-fast-properties": "^2.0.0"
+      },
+      "dependencies": {
+        "@babel/helper-validator-identifier": {
+          "version": "7.10.4",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.4.tgz",
+          "integrity": "sha512-3U9y+43hz7ZM+rzG24Qe2mufW5KhvFg/NhnNph+i9mgCtdTCtMJuI1TMkrIUiK7Ix4PYlRF9I5dhqaLYA/ADXw==",
+          "dev": true
+        }
       }
     },
     "@types/color-name": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
       "integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+      "dev": true
+    },
+    "@types/json5": {
+      "version": "0.0.29",
+      "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
+      "integrity": "sha1-7ihweulOEdK4J7y+UnC86n8+ce4=",
       "dev": true
     },
     "@zeit/schemas": {
@@ -431,9 +511,9 @@
       }
     },
     "binary-extensions": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.0.0.tgz",
-      "integrity": "sha512-Phlt0plgpIIBOGTT/ehfFnbNlfsDEiqmzE2KRXoX1bLIlir4X/MR+zSyBEkL05ffWgnRSf/DXv+WrUAVr93/ow==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/binary-extensions/-/binary-extensions-2.1.0.tgz",
+      "integrity": "sha512-1Yj8h9Q+QDF5FzhMs/c9+6UntbD5MkRfRwac8DoEm9ZfUBZ7tZ55YcGVAzEe4bXsdQHEk+s9S5wsOKVdZrw0tQ==",
       "dev": true
     },
     "bindings": {
@@ -803,9 +883,9 @@
       "dev": true
     },
     "concurrently": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-5.1.0.tgz",
-      "integrity": "sha512-9ViZMu3OOCID3rBgU31mjBftro2chOop0G2u1olq1OuwRBVRw/GxHTg80TVJBUTJfoswMmEUeuOg1g1yu1X2dA==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/concurrently/-/concurrently-5.2.0.tgz",
+      "integrity": "sha512-XxcDbQ4/43d6CxR7+iV8IZXhur4KbmEJk1CetVMUqCy34z9l0DkszbY+/9wvmSnToTej0SYomc2WSRH+L0zVJw==",
       "dev": true,
       "requires": {
         "chalk": "^2.4.2",
@@ -892,9 +972,9 @@
       "dev": true
     },
     "date-fns": {
-      "version": "2.11.1",
-      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.11.1.tgz",
-      "integrity": "sha512-3RdUoinZ43URd2MJcquzBbDQo+J87cSzB8NkXdZiN5ia1UNyep0oCyitfiL88+R7clGTeq/RniXAc16gWyAu1w==",
+      "version": "2.14.0",
+      "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.14.0.tgz",
+      "integrity": "sha512-1zD+68jhFgDIM0rF05rcwYO8cExdNqxjq4xP1QKM60Q45mnO6zaMWB4tOzrIr4M4GSLntsKeE4c9Bdl2jhL/yw==",
       "dev": true
     },
     "debug": {
@@ -1031,22 +1111,22 @@
       }
     },
     "es-abstract": {
-      "version": "1.17.5",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.5.tgz",
-      "integrity": "sha512-BR9auzDbySxOcfog0tLECW8l28eRGpDpU3Dm3Hp4q/N+VtLTmyj4EUN088XZWQDW/hzj6sYRDXeOFsaAODKvpg==",
+      "version": "1.17.6",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.17.6.tgz",
+      "integrity": "sha512-Fr89bON3WFyUi5EvAeI48QTWX0AyekGgLA8H+c+7fbfCkJwRWRMLd8CQedNEyJuoYYhmtEqY92pgte1FAhBlhw==",
       "dev": true,
       "requires": {
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "has": "^1.0.3",
         "has-symbols": "^1.0.1",
-        "is-callable": "^1.1.5",
-        "is-regex": "^1.0.5",
+        "is-callable": "^1.2.0",
+        "is-regex": "^1.1.0",
         "object-inspect": "^1.7.0",
         "object-keys": "^1.1.1",
         "object.assign": "^4.1.0",
-        "string.prototype.trimleft": "^2.1.1",
-        "string.prototype.trimright": "^2.1.1"
+        "string.prototype.trimend": "^1.0.1",
+        "string.prototype.trimstart": "^1.0.1"
       }
     },
     "es-to-primitive": {
@@ -1120,20 +1200,20 @@
       }
     },
     "eslint-config-airbnb-base": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.1.0.tgz",
-      "integrity": "sha512-+XCcfGyCnbzOnktDVhwsCAx+9DmrzEmuwxyHUJpw+kqBVT744OUBrB09khgFKlK1lshVww6qXGsYPZpavoNjJw==",
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-14.2.0.tgz",
+      "integrity": "sha512-Snswd5oC6nJaevs3nZoLSTvGJBvzTfnBqOIArkf3cbyTyq9UD79wOk8s+RiL6bhca0p/eRO6veczhf6A/7Jy8Q==",
       "dev": true,
       "requires": {
         "confusing-browser-globals": "^1.0.9",
         "object.assign": "^4.1.0",
-        "object.entries": "^1.1.1"
+        "object.entries": "^1.1.2"
       }
     },
     "eslint-config-athom": {
-      "version": "2.0.8",
-      "resolved": "https://registry.npmjs.org/eslint-config-athom/-/eslint-config-athom-2.0.8.tgz",
-      "integrity": "sha512-7QqvvRb7yGF7gCwgZtFBTz2wyFSrJaWr87owSinZO+giawRadBJFAkTWdh/+lsFRFdLP2wxJ2eKa7Qstj6Ii3w==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/eslint-config-athom/-/eslint-config-athom-2.1.0.tgz",
+      "integrity": "sha512-e7rZyvqF+QEnfWXbDTGUnnqU5G7F1BsKYzwZYTEBEjtUmesj23S0mVFem4jg399iAzkn1IrhpaXAdeADUF7c1A==",
       "dev": true,
       "requires": {
         "babel-eslint": "^10.0.3",
@@ -1144,9 +1224,9 @@
       }
     },
     "eslint-import-resolver-node": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.3.tgz",
-      "integrity": "sha512-b8crLDo0M5RSe5YG8Pu2DYBj71tSB6OvXkfzwbJU2w7y8P4/yo0MyF8jU26IEuEuHF2K5/gcAJE3LhQGqBBbVg==",
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.4.tgz",
+      "integrity": "sha512-ogtf+5AB/O+nM6DIeBUNr2fuT7ot9Qg/1harBfBtaP13ekEWFQEEMP94BCB7zaNW3gyY+8SHYF00rnqYwXKWOA==",
       "dev": true,
       "requires": {
         "debug": "^2.6.9",
@@ -1198,9 +1278,9 @@
       }
     },
     "eslint-plugin-es": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.0.tgz",
-      "integrity": "sha512-6/Jb/J/ZvSebydwbBJO1R9E5ky7YeElfK56Veh7e4QGFHCXoIXGH9HhVz+ibJLM3XJ1XjP+T7rKBLUa/Y7eIng==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-es/-/eslint-plugin-es-3.0.1.tgz",
+      "integrity": "sha512-GUmAsJaN4Fc7Gbtl8uOBlayo2DqhwWvEzykMHSCZHU3XdJ+NSzzZcVhXh3VxX5icqQ+oQdIEawXX8xkR3mIFmQ==",
       "dev": true,
       "requires": {
         "eslint-utils": "^2.0.0",
@@ -1208,9 +1288,9 @@
       },
       "dependencies": {
         "eslint-utils": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
-          "integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+          "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
           "dev": true,
           "requires": {
             "eslint-visitor-keys": "^1.1.0"
@@ -1225,23 +1305,24 @@
       }
     },
     "eslint-plugin-import": {
-      "version": "2.20.2",
-      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.20.2.tgz",
-      "integrity": "sha512-FObidqpXrR8OnCh4iNsxy+WACztJLXAHBO5hK79T1Hc77PgQZkyDGA5Ag9xAvRpglvLNxhH/zSmZ70/pZ31dHg==",
+      "version": "2.22.0",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.22.0.tgz",
+      "integrity": "sha512-66Fpf1Ln6aIS5Gr/55ts19eUuoDhAbZgnr6UxK5hbDx6l/QgQgx61AePq+BV4PP2uXQFClgMVzep5zZ94qqsxg==",
       "dev": true,
       "requires": {
-        "array-includes": "^3.0.3",
-        "array.prototype.flat": "^1.2.1",
+        "array-includes": "^3.1.1",
+        "array.prototype.flat": "^1.2.3",
         "contains-path": "^0.1.0",
         "debug": "^2.6.9",
         "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "^0.3.2",
-        "eslint-module-utils": "^2.4.1",
+        "eslint-import-resolver-node": "^0.3.3",
+        "eslint-module-utils": "^2.6.0",
         "has": "^1.0.3",
         "minimatch": "^3.0.4",
-        "object.values": "^1.1.0",
+        "object.values": "^1.1.1",
         "read-pkg-up": "^2.0.0",
-        "resolve": "^1.12.0"
+        "resolve": "^1.17.0",
+        "tsconfig-paths": "^3.9.0"
       },
       "dependencies": {
         "debug": {
@@ -1282,9 +1363,9 @@
       },
       "dependencies": {
         "eslint-utils": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
-          "integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+          "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
           "dev": true,
           "requires": {
             "eslint-visitor-keys": "^1.1.0"
@@ -1307,18 +1388,18 @@
       },
       "dependencies": {
         "eslint-utils": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
-          "integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.1.0.tgz",
+          "integrity": "sha512-w94dQYoauyvlDc43XnGB8lU3Zt713vNChgt4EWwhXAP2XkBvndfxF0AgIqKOOasjPIPzj9JqgwkwbCYD0/V3Zg==",
           "dev": true,
           "requires": {
             "eslint-visitor-keys": "^1.1.0"
           }
         },
         "ignore": {
-          "version": "5.1.4",
-          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
-          "integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A==",
+          "version": "5.1.8",
+          "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.8.tgz",
+          "integrity": "sha512-BMpfD7PpiETpBl/A6S498BaIJ6Y/ABT93ETbby2fP00v4EbvPBXWEoaR1UBPKs3iR53pJY7EtZk5KACI57i1Uw==",
           "dev": true
         },
         "semver": {
@@ -1710,9 +1791,9 @@
       "dev": true
     },
     "fsevents": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.2.tgz",
-      "integrity": "sha512-R4wDiBwZ0KzpgOWetKDug1FZcYhqYnUYKtfZYt4mD5SBz76q0KR4Q9o7GIPamsVPGmW3EYPPJ0dOOjvx32ldZA==",
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.1.3.tgz",
+      "integrity": "sha512-Auw9a4AxqWpa9GUfj370BMPzzyncfBABW8Mab7BGWBYDj4Isgq+cDKtx0i6u9jcX9pQDnswsaaOTgTmA5pEjuQ==",
       "dev": true,
       "optional": true
     },
@@ -2133,9 +2214,9 @@
       "dev": true
     },
     "is-callable": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.1.5.tgz",
-      "integrity": "sha512-ESKv5sMCJB2jnHTWZ3O5itG+O128Hsus4K4Qh1h2/cgn2vbgnLSVqfV46AeJA9D5EeeLa9w81KUXMtn34zhX+Q==",
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.0.tgz",
+      "integrity": "sha512-pyVD9AaGLxtg6srb2Ng6ynWJqkHU9bEM087AKck0w8QwDarTfNcpIYoU8x8Hv2Icm8u6kFJM18Dag8lyqGkviw==",
       "dev": true
     },
     "is-ci": {
@@ -2284,12 +2365,12 @@
       "dev": true
     },
     "is-regex": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
-      "integrity": "sha512-vlKW17SNq44owv5AQR3Cq0bQPEb8+kF3UKZ2fiZNOWtztYE5i0CzCZxFDwO58qAOWtxdBRVO/V5Qin1wjCqFYQ==",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.0.tgz",
+      "integrity": "sha512-iI97M8KTWID2la5uYXlkbSDQIg4F6o1sYboZKKTDpnDQMLtUL86zxhgDet3Q2SriaYsyGqZ6Mn2SjbRKeLHdqw==",
       "dev": true,
       "requires": {
-        "has": "^1.0.3"
+        "has-symbols": "^1.0.1"
       }
     },
     "is-retry-allowed": {
@@ -2427,6 +2508,15 @@
       "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
       "integrity": "sha1-nbe1lJatPzz+8wp1FC0tkwrXJlE=",
       "dev": true
+    },
+    "json5": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
+      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "dev": true,
+      "requires": {
+        "minimist": "^1.2.0"
+      }
     },
     "kind-of": {
       "version": "6.0.3",
@@ -2774,9 +2864,9 @@
       }
     },
     "mocha": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.1.1.tgz",
-      "integrity": "sha512-3qQsu3ijNS3GkWcccT5Zw0hf/rWvu1fTN9sPvEd81hlwsr30GX2GcDSSoBxo24IR8FelmrAydGC6/1J5QQP4WA==",
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/mocha/-/mocha-7.2.0.tgz",
+      "integrity": "sha512-O9CIypScywTVpNaRrCAgoUnJgozpIofjKUYmJhiCIJMiuYnLI6otcb1/kpW9/n/tJODHGZ7i8aLQoDVsMtOKQQ==",
       "dev": true,
       "requires": {
         "ansi-colors": "3.2.3",
@@ -2792,7 +2882,7 @@
         "js-yaml": "3.13.1",
         "log-symbols": "3.0.0",
         "minimatch": "3.0.4",
-        "mkdirp": "0.5.3",
+        "mkdirp": "0.5.5",
         "ms": "2.1.1",
         "node-environment-flags": "1.0.6",
         "object.assign": "4.1.0",
@@ -2826,15 +2916,6 @@
             "minimatch": "^3.0.4",
             "once": "^1.3.0",
             "path-is-absolute": "^1.0.0"
-          }
-        },
-        "mkdirp": {
-          "version": "0.5.3",
-          "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
-          "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
-          "dev": true,
-          "requires": {
-            "minimist": "^1.2.5"
           }
         },
         "ms": {
@@ -3210,9 +3291,9 @@
       }
     },
     "object-inspect": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.7.0.tgz",
-      "integrity": "sha512-a7pEHdh1xKIAgTySUGgLMx/xwDZskN1Ud6egYYN3EdRW4ZMPNEDUTF+hwy2LUC+Bl+SyLXANnwz/jyh/qutKUw==",
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.8.0.tgz",
+      "integrity": "sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==",
       "dev": true
     },
     "object-keys": {
@@ -3243,14 +3324,13 @@
       }
     },
     "object.entries": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.1.tgz",
-      "integrity": "sha512-ilqR7BgdyZetJutmDPfXCDffGa0/Yzl2ivVNpbx/g4UeWrCdRnFDUBrKJGLhGieRHDATnyZXWBeCb29k9CJysQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/object.entries/-/object.entries-1.1.2.tgz",
+      "integrity": "sha512-BQdB9qKmb/HyNdMNWVr7O3+z5MUIx3aiegEIJqjMBbBf0YT9RRxTJSim4mzFqtyr7PDAHigq0N9dO0m0tRakQA==",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.0-next.1",
-        "function-bind": "^1.1.1",
+        "es-abstract": "^1.17.5",
         "has": "^1.0.3"
       }
     },
@@ -3771,9 +3851,9 @@
       }
     },
     "resolve": {
-      "version": "1.15.1",
-      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.15.1.tgz",
-      "integrity": "sha512-84oo6ZTtoTUpjgNEr5SJyzQhzL72gaRodsSfyxC/AXRvwu0Yse9H8eF9IpGo7b8YetZhlI6v7ZQ6bKBFV/6S7w==",
+      "version": "1.17.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+      "integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
       "dev": true,
       "requires": {
         "path-parse": "^1.0.6"
@@ -4193,9 +4273,9 @@
       "dev": true
     },
     "spdx-correct": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.0.tgz",
-      "integrity": "sha512-lr2EZCctC2BNR7j7WzJ2FpDznxky1sjfxvvYEyzxNyb6lZXHODmEoJeFu4JupYlkfha1KZpJyoqiJ7pgA1qq8Q==",
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-3.1.1.tgz",
+      "integrity": "sha512-cOYcUWwhCuHCXi49RhFRCyJEK3iPj1Ziz9DpViV3tbZOwXD49QzIN3MpOLJNxh2qwq2lJJZaKMVw9qNi4jTC0w==",
       "dev": true,
       "requires": {
         "spdx-expression-parse": "^3.0.0",
@@ -4203,15 +4283,15 @@
       }
     },
     "spdx-exceptions": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.2.0.tgz",
-      "integrity": "sha512-2XQACfElKi9SlVb1CYadKDXvoajPgBVPn/gOQLrTvHdElaVhr7ZEbqJaRnJLVNeaI4cMEAgVCeBMKF6MWRDCRA==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
       "dev": true
     },
     "spdx-expression-parse": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.0.tgz",
-      "integrity": "sha512-Yg6D3XpRD4kkOmTpdgbUiEJFKghJH03fiC1OPll5h/0sO6neh2jqRDVHOQ4o/LMea0tgCkbMgea5ip/e+MkWyg==",
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
       "dev": true,
       "requires": {
         "spdx-exceptions": "^2.1.0",
@@ -4272,41 +4352,19 @@
       }
     },
     "string.prototype.trimend": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.0.tgz",
-      "integrity": "sha512-EEJnGqa/xNfIg05SxiPSqRS7S9qwDhYts1TSLR1BQfYUfPe1stofgGKvwERK9+9yf+PpfBMlpBaCHucXGPQfUA==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.1.tgz",
+      "integrity": "sha512-LRPxFUaTtpqYsTeNKaFOw3R4bxIzWOnbQ837QfBylo8jIxtcbK/A/sMV7Q+OAV/vWo+7s25pOE10KYSjaSO06g==",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
         "es-abstract": "^1.17.5"
       }
     },
-    "string.prototype.trimleft": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimleft/-/string.prototype.trimleft-2.1.2.tgz",
-      "integrity": "sha512-gCA0tza1JBvqr3bfAIFJGqfdRTyPae82+KTnm3coDXkZN9wnuW3HjGgN386D7hfv5CHQYCI022/rJPVlqXyHSw==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5",
-        "string.prototype.trimstart": "^1.0.0"
-      }
-    },
-    "string.prototype.trimright": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimright/-/string.prototype.trimright-2.1.2.tgz",
-      "integrity": "sha512-ZNRQ7sY3KroTaYjRS6EbNiiHrOkjihL9aQE/8gfQ4DtAC/aEBRHFJa44OmoWxGGqXuJlfKkZW4WcXErGr+9ZFg==",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.3",
-        "es-abstract": "^1.17.5",
-        "string.prototype.trimend": "^1.0.0"
-      }
-    },
     "string.prototype.trimstart": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.0.tgz",
-      "integrity": "sha512-iCP8g01NFYiiBOnwG1Xc3WZLyoo+RuBymwIlWncShXDDJYWN6DbnM3odslBJdgCdRlq94B5s63NWAZlcn2CS4w==",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.1.tgz",
+      "integrity": "sha512-XxZn+QpvrBI1FOcg6dIpxUPgWCPuNXvMD72aaRaUQv1eD4e/Qy8i/hFTe0BUmD60p/QA6bh1avmuPTfNjqVWRw==",
       "dev": true,
       "requires": {
         "define-properties": "^1.1.3",
@@ -4500,6 +4558,18 @@
       "resolved": "https://registry.npmjs.org/tree-kill/-/tree-kill-1.2.2.tgz",
       "integrity": "sha512-L0Orpi8qGpRG//Nd+H90vFB+3iHnue1zSSGmNOOCh1GLJ7rUKVwV2HvijphGQS2UmhUZewS9VgvxYIdgr+fG1A==",
       "dev": true
+    },
+    "tsconfig-paths": {
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/tsconfig-paths/-/tsconfig-paths-3.9.0.tgz",
+      "integrity": "sha512-dRcuzokWhajtZWkQsDVKbWyY+jgcLC5sqJhg2PSgf4ZkH2aHPvaOY8YWGhmjb68b5qqTfasSsDO9k7RUiEmZAw==",
+      "dev": true,
+      "requires": {
+        "@types/json5": "^0.0.29",
+        "json5": "^1.0.1",
+        "minimist": "^1.2.0",
+        "strip-bom": "^3.0.0"
+      }
     },
     "tslib": {
       "version": "1.11.1",

--- a/package.json
+++ b/package.json
@@ -31,13 +31,13 @@
   "homepage": "https://github.com/athombv/node-zigbee-clusters#readme",
   "devDependencies": {
     "braintree-jsdoc-template": "^3.3.0",
-    "concurrently": "^5.1.0",
+    "concurrently": "^5.2.0",
     "eslint": "^6.8.0",
-    "eslint-config-athom": "^2.0.8",
+    "eslint-config-athom": "^2.1.0",
     "jsdoc": "^3.6.4",
+    "mocha": "^7.2.0",
     "npm-watch": "^0.6.0",
-    "serve": "^11.3.1",
-    "mocha": "^7.1.0"
+    "serve": "^11.3.1"
   },
   "dependencies": {
     "@athombv/data-types": "^1.0.4",

--- a/test/manual/xiaomiHacks.js
+++ b/test/manual/xiaomiHacks.js
@@ -72,7 +72,6 @@ const XiaomiLifelineDataRecordArray = new ZCLDataType(NaN, 'XiaomiLifelineDataRe
   return result;
 });
 
-
 class XiaomiHackedBasicCluster extends BasicCluster {
 
   static get ATTRIBUTES() {
@@ -87,7 +86,6 @@ class XiaomiHackedBasicCluster extends BasicCluster {
 // Replace basic cluster with our patched version
 Cluster.addCluster(XiaomiHackedBasicCluster);
 
-
 // //Demo non-meshdriver zigbee API:
 // const OnOffCluster = require('homey-zcl/zcl/onOff');
 
@@ -98,7 +96,6 @@ Cluster.addCluster(XiaomiHackedBasicCluster);
 // const {modelId, dateCode} = await node.endpoints[1].basic.readAttributes('modelId', 'dateCode');
 // node.endpoint[1].clusters.basic.configureReporting({
 // powerSource: {minInterval: 1234, maxInterval: 4321, minChange: 10}}); //enables reporting
-
 
 // TODO: invert group commands
 // class LocalOnOffCluster {

--- a/test/testMfgSpecificCommands.js
+++ b/test/testMfgSpecificCommands.js
@@ -1,15 +1,40 @@
 // eslint-disable-next-line max-classes-per-file,lines-around-directive
 'use strict';
 
-let { debug } = require('./util');
+const assert = require('assert');
 const Cluster = require('../lib/Cluster');
 const { ZCLDataTypes } = require('../lib/zclTypes');
 const BoundCluster = require('../lib/BoundCluster');
 const SceneCluster = require('../lib/clusters/scenes');
 
-debug = debug.extend('test-manufacturer-specific-commands');
+const MANUFACTURER_ID_1 = 0x1234;
+const MANUFACTURER_ID_2 = 0x4321;
 
 class IkeaSceneCluster extends SceneCluster {
+
+  static get ATTRIBUTES() {
+    return {
+      sceneCount: {
+        id: 0,
+        type: ZCLDataTypes.uint8,
+        manufacturerId: MANUFACTURER_ID_1, // Fake manufacturer specific attribute
+      },
+      currentScene: {
+        id: 1,
+        type: ZCLDataTypes.uint8,
+        manufacturerId: MANUFACTURER_ID_2, // Fake manufacturer specific attribute
+      },
+      currentGroup: {
+        id: 2,
+        type: ZCLDataTypes.uint16,
+        manufacturerId: MANUFACTURER_ID_2, // Fake manufacturer specific attribute
+      },
+      sceneValid: {
+        id: 3,
+        type: ZCLDataTypes.bool,
+      },
+    };
+  }
 
   static get COMMANDS() {
     return {
@@ -59,39 +84,231 @@ const node = loopbackNode([
   },
 ]);
 
-const tst = node.endpoints[1].clusters['scenes'];
-
 class IkeaBoundCluster extends BoundCluster {
 
-  async ikeaSceneStep(args) {
-    debug(args);
-  }
-
-  async ikeaSceneMove(args) {
-    debug(args);
-  }
-
-  async ikeaSceneMoveStop(args) {
-    debug(args);
+  constructor({
+    onReadAttributes,
+    onWriteAttributes,
+    onConfigureReporting,
+    onReadReportingConfiguration,
+    onIkeaSceneStep,
+    onIkeaSceneMove,
+    onIkeaSceneMoveStop,
+  } = {}) {
+    super();
+    if (onReadAttributes) this.readAttributes = onReadAttributes;
+    if (onWriteAttributes) this.writeAttributes = onWriteAttributes;
+    if (onConfigureReporting) this.configureReporting = onConfigureReporting;
+    if (onReadReportingConfiguration) {
+      this.readReportingConfiguration = onReadReportingConfiguration;
+    }
+    if (onIkeaSceneStep) this.ikeaSceneStep = onIkeaSceneStep;
+    if (onIkeaSceneMove) this.ikeaSceneMove = onIkeaSceneMove;
+    if (onIkeaSceneMoveStop) this.ikeaSceneMoveStop = onIkeaSceneMoveStop;
   }
 
 }
 
 describe('manufacturer specific commands', function() {
-  it('should execute', function() {
-    node.endpoints[1].bind('scenes', new IkeaBoundCluster());
-
-    tst.ikeaSceneStep({
+  it('should execute custom commands', function(done) {
+    let commandsExecuted = 0;
+    const ikeaSceneStepCommand = {
       mode: 'up',
       stepSize: 1,
       transitionTime: 13,
-    });
-    tst.ikeaSceneMove({
+    };
+    const ikeaSceneMoveCommand = {
       mode: 'up',
       transitionTime: 13,
-    });
-    tst.ikeaSceneMoveStop({
+    };
+    const ikeaSceneMoveStop = {
       duration: 1000,
+    };
+    node.endpoints[1].bind('scenes', new IkeaBoundCluster({
+      onIkeaSceneStep: payload => {
+        commandsExecuted++;
+        assert.deepStrictEqual({ ...payload }, ikeaSceneStepCommand);
+        if (commandsExecuted === 3) done();
+      },
+      onIkeaSceneMove: payload => {
+        commandsExecuted++;
+        assert.deepStrictEqual({ ...payload }, ikeaSceneMoveCommand);
+        if (commandsExecuted === 3) done();
+      },
+      onIkeaSceneMoveStop: payload => {
+        commandsExecuted++;
+        assert.deepStrictEqual({ ...payload }, ikeaSceneMoveStop);
+        if (commandsExecuted === 3) done();
+      },
+    }));
+
+    node.endpoints[1].clusters['scenes'].ikeaSceneStep(ikeaSceneStepCommand);
+    node.endpoints[1].clusters['scenes'].ikeaSceneMove(ikeaSceneMoveCommand);
+    node.endpoints[1].clusters['scenes'].ikeaSceneMoveStop(ikeaSceneMoveStop);
+  });
+
+  describe('global commands', function() {
+    describe('readAttributes', function() {
+      it('should set correct manufacturerId', function(done) {
+        node.endpoints[1].bind('scenes', new IkeaBoundCluster({
+          onReadAttributes: (payload, meta, rawPayload) => {
+            assert.strictEqual(MANUFACTURER_ID_1, rawPayload.manufacturerId);
+            done();
+          },
+        }));
+        node.endpoints[1].clusters['scenes'].readAttributes('sceneCount');
+      });
+      it('should throw when different manufacturerIds are found', function(done) {
+        node.endpoints[1].clusters['scenes'].readAttributes('sceneCount', 'currentScene')
+          .catch(err => {
+            assert(err instanceof Error);
+            done();
+          });
+      });
+      it('should set correct manufacturerId for multiple attributes', function(done) {
+        node.endpoints[1].bind('scenes', new IkeaBoundCluster({
+          onReadAttributes: (payload, meta, rawPayload) => {
+            assert.strictEqual(MANUFACTURER_ID_2, rawPayload.manufacturerId);
+            done();
+          },
+        }));
+
+        node.endpoints[1].clusters['scenes'].readAttributes('currentScene', 'currentGroup');
+      });
+      it('should not set manufacturerId when zcl attribute is present', function(done) {
+        node.endpoints[1].bind('scenes', new IkeaBoundCluster({
+          onReadAttributes: (payload, meta, rawPayload) => {
+            assert.strictEqual(undefined, rawPayload.manufacturerId);
+            done();
+          },
+        }));
+
+        node.endpoints[1].clusters['scenes'].readAttributes('sceneValid');
+      });
+    });
+
+    describe('writeAttributes', function() {
+      it('should set correct manufacturerId', function(done) {
+        node.endpoints[1].bind('scenes', new IkeaBoundCluster({
+          onWriteAttributes: (payload, meta, rawPayload) => {
+            assert.strictEqual(MANUFACTURER_ID_1, rawPayload.manufacturerId);
+            done();
+          },
+        }));
+        node.endpoints[1].clusters['scenes'].writeAttributes({ sceneCount: 1 });
+      });
+      it('should throw when different manufacturerIds are found', function(done) {
+        node.endpoints[1].clusters['scenes'].writeAttributes({ sceneCount: 1, currentScene: 2 })
+          .catch(err => {
+            assert(err instanceof Error);
+            done();
+          });
+      });
+      it('should set correct manufacturerId for multiple attributes', function(done) {
+        node.endpoints[1].bind('scenes', new IkeaBoundCluster({
+          onWriteAttributes: (payload, meta, rawPayload) => {
+            assert.strictEqual(MANUFACTURER_ID_2, rawPayload.manufacturerId);
+            done();
+          },
+        }));
+
+        node.endpoints[1].clusters['scenes'].writeAttributes({ currentScene: 1, currentGroup: 2 });
+      });
+      it('should not set manufacturerId when zcl attribute is present', function(done) {
+        node.endpoints[1].bind('scenes', new IkeaBoundCluster({
+          onWriteAttributes: (payload, meta, rawPayload) => {
+            assert.strictEqual(undefined, rawPayload.manufacturerId);
+            done();
+          },
+        }));
+
+        node.endpoints[1].clusters['scenes'].writeAttributes({ sceneValid: true });
+      });
+    });
+
+    describe('configureReporting', function() {
+      it('should set correct manufacturerId', function(done) {
+        node.endpoints[1].bind('scenes', new IkeaBoundCluster({
+          onConfigureReporting: (payload, meta, rawPayload) => {
+            assert.strictEqual(MANUFACTURER_ID_1, rawPayload.manufacturerId);
+            done();
+          },
+        }));
+        node.endpoints[1].clusters['scenes'].configureReporting({ sceneCount: { minInterval: 0, maxInterval: 300, minChange: 1 } });
+      });
+      it('should throw when different manufacturerIds are found', function(done) {
+        node.endpoints[1].clusters['scenes'].configureReporting({
+          sceneCount: { minInterval: 0, maxInterval: 300, minChange: 1 },
+          currentScene: { minInterval: 0, maxInterval: 300, minChange: 1 },
+        })
+          .catch(err => {
+            assert(err instanceof Error);
+            done();
+          });
+      });
+      it('should set correct manufacturerId for multiple attributes', function(done) {
+        node.endpoints[1].bind('scenes', new IkeaBoundCluster({
+          onConfigureReporting: (payload, meta, rawPayload) => {
+            assert.strictEqual(MANUFACTURER_ID_2, rawPayload.manufacturerId);
+            done();
+          },
+        }));
+        node.endpoints[1].clusters['scenes'].configureReporting({
+          currentScene: { minInterval: 0, maxInterval: 300, minChange: 1 },
+          currentGroup: { minInterval: 0, maxInterval: 300, minChange: 1 },
+        });
+      });
+      it('should not set manufacturerId when zcl attribute is present', function(done) {
+        node.endpoints[1].bind('scenes', new IkeaBoundCluster({
+          onConfigureReporting: (payload, meta, rawPayload) => {
+            assert.strictEqual(undefined, rawPayload.manufacturerId);
+            done();
+          },
+        }));
+
+        node.endpoints[1].clusters['scenes'].configureReporting({
+          sceneValid: { minInterval: 0, maxInterval: 300, minChange: 1 },
+          currentGroup: { minInterval: 0, maxInterval: 300, minChange: 1 },
+        });
+      });
+    });
+
+    describe('readReportingConfiguration', function() {
+      it('should set correct manufacturerId', function(done) {
+        node.endpoints[1].bind('scenes', new IkeaBoundCluster({
+          onReadReportingConfiguration: (payload, meta, rawPayload) => {
+            assert.strictEqual(MANUFACTURER_ID_1, rawPayload.manufacturerId);
+            done();
+          },
+        }));
+        node.endpoints[1].clusters['scenes'].readReportingConfiguration(['sceneCount']);
+      });
+      it('should throw when different manufacturerIds are found', function(done) {
+        node.endpoints[1].clusters['scenes'].readReportingConfiguration(['sceneCount', 'currentScene'])
+          .catch(err => {
+            assert(err instanceof Error);
+            done();
+          });
+      });
+      it('should set correct manufacturerId for multiple attributes', function(done) {
+        node.endpoints[1].bind('scenes', new IkeaBoundCluster({
+          onReadReportingConfiguration: (payload, meta, rawPayload) => {
+            assert.strictEqual(MANUFACTURER_ID_2, rawPayload.manufacturerId);
+            done();
+          },
+        }));
+        node.endpoints[1].clusters['scenes'].readReportingConfiguration(['currentGroup', 'currentScene']);
+      });
+      it('should not set manufacturerId when zcl attribute is present', function(done) {
+        node.endpoints[1].bind('scenes', new IkeaBoundCluster({
+          onReadReportingConfiguration: (payload, meta, rawPayload) => {
+            assert.strictEqual(undefined, rawPayload.manufacturerId);
+            done();
+          },
+        }));
+
+        node.endpoints[1].clusters['scenes'].readReportingConfiguration(['currentGroup', 'sceneValid']);
+      });
     });
   });
 });


### PR DESCRIPTION
This PR fixes that some global commands would not set the manufacturerId/manufacturerSpecific fields when working with manufacturer specific attributes.

The following methods were changed to detect if the manufacturerId/manufacturerSpecific fields should be set:
- `readAttributes`
- `writeAttributes`
- `configureAttributeReporting`
- `readReportingConfiguration`

Additional changes:
- ESLint fixes
- Dependency updates