### PR TITLE
Complete iasZone definition

### DIFF
--- a/lib/clusters/iasZone.js
+++ b/lib/clusters/iasZone.js
@@ -3,6 +3,8 @@
 const Cluster = require('../Cluster');
 const { ZCLDataTypes } = require('../zclTypes');
 
+const ZONE_STATUS_DATA_TYPE = ZCLDataTypes.map16('alarm1', 'alarm2', 'tamper', 'battery', 'supervisionReports', 'restoreReports', 'trouble', 'acMains', 'test', 'batteryDefect');
+
 const ATTRIBUTES = {
   zoneState: {
     id: 0,
@@ -33,7 +35,7 @@ const ATTRIBUTES = {
   },
   zoneStatus: {
     id: 2,
-    type: ZCLDataTypes.map16('alarm1', 'alarm2', 'tamper', 'battery', 'supervisionReports', 'restoreReports', 'trouble', 'acMains', 'test', 'batteryDefect'),
+    type: ZONE_STATUS_DATA_TYPE,
   },
   iasCIEAddress: {
     id: 16,
@@ -49,7 +51,7 @@ const COMMANDS = {
   zoneStatusChangeNotification: {
     id: 0,
     args: {
-      zoneStatus: ZCLDataTypes.map16('alarm1', 'alarm2', 'tamper', 'battery', 'supervisionReports', 'restoreReports', 'trouble', 'acMains', 'test', 'batteryDefect'),
+      zoneStatus: ZONE_STATUS_DATA_TYPE,
       extendedStatus: ZCLDataTypes.uint8,
       zoneId: ZCLDataTypes.uint8,
       delay: ZCLDataTypes.uint16,

--- a/lib/clusters/iasZone.js
+++ b/lib/clusters/iasZone.js
@@ -13,7 +13,7 @@ const ATTRIBUTES = {
   },
   zoneType: {
     id: 1,
-    type: ZCLDataTypes.enum8({
+    type: ZCLDataTypes.enum16({
       standardCIE: 0,
       motionSensor: 13,
       contactSwitch: 21,
@@ -27,7 +27,7 @@ const ATTRIBUTES = {
       keypad: 541,
       standardWarningDevice: 549,
       glassBreakSensor: 550,
-      securityRepeaters: 553,
+      securityRepeater: 553,
       invalidZoneType: 65535,
     }),
   },
@@ -39,7 +39,7 @@ const ATTRIBUTES = {
     id: 16,
     type: ZCLDataTypes.EUI64,
   },
-  zoneID: {
+  zoneId: {
     id: 17,
     type: ZCLDataTypes.uint8,
   },
@@ -51,7 +51,7 @@ const COMMANDS = {
     args: {
       zoneStatus: ZCLDataTypes.map16('alarm1', 'alarm2', 'tamper', 'battery', 'supervisionReports', 'restoreReports', 'trouble', 'acMains', 'test', 'batteryDefect'),
       extendedStatus: ZCLDataTypes.uint8,
-      zoneID: ZCLDataTypes.uint8,
+      zoneId: ZCLDataTypes.uint8,
       delay: ZCLDataTypes.uint16,
     },
   },

--- a/lib/clusters/iasZone.js
+++ b/lib/clusters/iasZone.js
@@ -1,11 +1,61 @@
 'use strict';
 
 const Cluster = require('../Cluster');
+const { ZCLDataTypes } = require('../zclTypes');
 
 const ATTRIBUTES = {
+  zoneState: {
+    id: 0,
+    type: ZCLDataTypes.enum8({
+      notEnrolled: 0,
+      enrolled: 1,
+    }),
+  },
+  zoneType: {
+    id: 1,
+    type: ZCLDataTypes.enum8({
+      standardCIE: 0,
+      motionSensor: 13,
+      contactSwitch: 21,
+      fireSensor: 40,
+      waterSensor: 42,
+      cabonMonoxideSensor: 43,
+      personalEmergencyDevice: 44,
+      vibrationMovementSensor: 45,
+      remoteControl: 271,
+      keyfob: 277,
+      keypad: 541,
+      standardWarningDevice: 549,
+      glassBreakSensor: 550,
+      securityRepeaters: 553,
+      invalidZoneType: 65535,
+    }),
+  },
+  zoneStatus: {
+    id: 2,
+    type: ZCLDataTypes.map16('alarm1', 'alarm2', 'tamper', 'battery', 'supervisionReports', 'restoreReports', 'trouble', 'acMains', 'test', 'batteryDefect'),
+  },
+  iasCIEAddress: {
+    id: 16,
+    type: ZCLDataTypes.EUI64,
+  },
+  zoneID: {
+    id: 17,
+    type: ZCLDataTypes.uint8,
+  },
 };
 
-const COMMANDS = {};
+const COMMANDS = {
+  zoneStatusChangeNotification: {
+    id: 0,
+    args: {
+      zoneStatus: ZCLDataTypes.map16('alarm1', 'alarm2', 'tamper', 'battery', 'supervisionReports', 'restoreReports', 'trouble', 'acMains', 'test', 'batteryDefect'),
+      extendedStatus: ZCLDataTypes.uint8,
+      zoneID: ZCLDataTypes.uint8,
+      delay: ZCLDataTypes.uint16,
+    },
+  },
+};
 
 class IASZoneCluster extends Cluster {
 


### PR DESCRIPTION
tested to be working.

For zoneState and zoneType I removed (preventively) the definition comments (out of specification document)

```
  zoneState: {
    id: 0,
    type: ZCLDataTypes.enum8({
      notEnrolled: 0, // 0x00 Not enrolled
      Enrolled: 1, // 0x01 Enrolled (the client will react to Zone State Change Notification commands from the server)
    }),
  },
  zoneType: {
    id: 1, type: ZCLDataTypes.enum8({
      standardCIE: 0, // 0x0000 Standard CIE System Alarm -
      motionSensor: 13, //0x000d Motion sensor Intrusion indication Presence indication
      contactSwitch: 21, //0x0015 Contact switch 1st portal Open-Close 2nd portal Open-Close
      fireSensor: 40, //0x0028 Fire sensor Fire indication -
      waterSensor: 42, //0x002a Water sensor Water overflow indication -
      cabonMonoxideSensor: 43, //0x002b Carbon Monoxide (CO) sensor CO indication Cooking indication
      personalEmergencyDevice: 44, // 0x002c Personal emergency device Fall/Concussion Emergency button
      vibrationMovementSensor: 45, // 0x002d Vibration/Movement sensor Movement indication Vibration
      remoteControl: 271, //0x010f Remote Control Panic Emergency
      keyfob: 277, //0x0115 Key fob Panic Emergency
      keypad: 541, //0x021d Keypad Panic Emergency
      standardWarningDevice: 549, // 0x0225 Standard Warning Device
      glassBreakSensor: 550, //0x0226 Glass break sensor Glass breakage detected -
      securityRepeaters: 553, //0x0229 Security repeater* - -
      // 0x8000-0xfffe manufacturer specific types - -
      invalidZoneType: 65535, //0xffff Invalid Zone Type
    }),
  },
```