### PR TITLE
feat: implement command direction property

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ Make sure to take a look at the API documentation: [https://athombv.github.io/no
 
 A Zigbee cluster is an abstraction on top of the Zigbee protocol which allows implementing functionality for many types of devices. A list of all available clusters can be found in the Zigbee Cluster Library Specification [section 2.2.](https://etc.athom.com/zigbee_cluster_specification.pdf). If you are familiar with Z-Wave Command Classes, Zigbee clusters are very similar.
 
-### Cluster hierachy
+### Cluster hierarchy
 
 It is important to understand the structure of a Zigbee node:
 [![](https://mermaid.ink/img/eyJjb2RlIjoiZ3JhcGggVERcbiAgQVtOb2RlXSAtLT4gQihFbmRwb2ludCAxKVxuICBBIC0tPiBEKEVuZHBvaW50IC4uLilcbiAgQiAtLT4gRShDbHVzdGVyIE9uT2ZmKVxuICBCIC0tPiBGKENsdXN0ZXIgTGV2ZWxDb250cm9sKVxuICBCIC0tPiBHKENsdXN0ZXIgLi4uKVxuICBFIC0tPiBIKENvbW1hbmQgJ3RvZ2dsZScpXG4gIEUgLS0-IEkoQ29tbWFuZCAnc2V0T24nKVxuICBFIC0tPiBKKEF0dHJpYnV0ZSAnb25PZmYnKSIsIm1lcm1haWQiOnsidGhlbWUiOiJkZWZhdWx0In0sInVwZGF0ZUVkaXRvciI6ZmFsc2V9)](https://mermaid-js.github.io/mermaid-live-editor/#/edit/eyJjb2RlIjoiZ3JhcGggVERcbiAgQVtOb2RlXSAtLT4gQihFbmRwb2ludCAxKVxuICBBIC0tPiBEKEVuZHBvaW50IC4uLilcbiAgQiAtLT4gRShDbHVzdGVyIE9uT2ZmKVxuICBCIC0tPiBGKENsdXN0ZXIgTGV2ZWxDb250cm9sKVxuICBCIC0tPiBHKENsdXN0ZXIgLi4uKVxuICBFIC0tPiBIKENvbW1hbmQgJ3RvZ2dsZScpXG4gIEUgLS0-IEkoQ29tbWFuZCAnc2V0T24nKVxuICBFIC0tPiBKKEF0dHJpYnV0ZSAnb25PZmYnKSIsIm1lcm1haWQiOnsidGhlbWUiOiJkZWZhdWx0In0sInVwZGF0ZUVkaXRvciI6ZmFsc2V9)
@@ -30,7 +30,7 @@ A cluster can be implemented in two ways:
 From the Zigbee Cluster Library Specification "Typically, the entity that stores the attributes of a cluster is referred to as the server of that cluster and an entity that affects or manipulates those attributes is referred to as the client of that cluster." More information on this can be found in the Zigbee Cluster Library Specification [section 2.2.2.](https://etc.athom.com/zigbee_cluster_specification.pdf).
 
 ### Bindings and bound clusters
-The concept of server/client is important for the following reason. Nodes can be receivers of commands (i.e. servers), or senders of commands (i.e. clients), and sometimes both. An example on how to send a command to a node can be found [below](#basic-communication-with-node). Receiving commands from a node requires a binding to be made from the controller to the cluster on the node, and the implementation of a `BoundCluster` to receive and handle the incoming commands. For an example on implementing a `BoundCluster` see [below](#implementing-a-bound-cluster).
+The concept of server/client is important for the following reason. Nodes can be receivers of commands (i.e. servers), or senders of commands (i.e. clients), and sometimes both. An example on how to send a command to a node can be found [below](#basic-communication-with-node). Receiving commands from a node requires a binding to be made from the controller to the cluster on the node, and the implementation of a `BoundCluster` (i.e. server cluster) to receive and handle the incoming commands. For an example on implementing a `BoundCluster` see [below](#implementing-a-bound-cluster).
 
 ## Usage
 
@@ -124,8 +124,10 @@ const COMMANDS = {
   toggle: { id: 2 },
   onWithTimedOff: {
     id: 66,
+    // Optional property that can be used to implement two commands with the same id but different directions. Both commands must have a direction property in that case. See lib/clusters/iasZone.js as example.
+    // direction: Cluster.DIRECTION_SERVER_TO_CLIENT
     args: {
-      onOffControl: ZCLDataTypes.uint8, // Use the `ZCLDataTypes` object to specifiy types
+      onOffControl: ZCLDataTypes.uint8, // Use the `ZCLDataTypes` object to specify types
       onTime: ZCLDataTypes.uint16,
       offWaitTime: ZCLDataTypes.uint16,
     },

--- a/lib/Cluster.js
+++ b/lib/Cluster.js
@@ -305,6 +305,15 @@ class Cluster extends EventEmitter {
   }
 
   /**
+   * Constants that refer to the direction of a frame. The direction of a frame
+   * is read from the frameControl property in the ZCL header. Usually a client cluster
+   * sends commands to a server cluster (the cluster holding the attribute values), but
+   * this can also be the other way around.
+   */
+  static DIRECTION_SERVER_TO_CLIENT = 'DIRECTION_SERVER_TO_CLIENT';
+  static DIRECTION_CLIENT_TO_SERVER = 'DIRECTION_CLIENT_TO_SERVER';
+
+  /**
    * Returns log id string for this cluster.
    * @returns {string}
    */
@@ -691,11 +700,34 @@ class Cluster extends EventEmitter {
   async handleFrame(frame, meta, rawFrame) {
     const commands = this.constructor.commandsById[frame.cmdId] || [];
 
-    // Determine correct command
-    const command = commands.filter(cmd => frame.frameControl.clusterSpecific === !cmd.global
+    // Filter commands of this cluster based on cluster specific vs global,
+    // and manufacturer specific vs not manufacturer specific.
+    let filteredCommands = commands.filter(cmd => frame.frameControl.clusterSpecific === !cmd.global
       && (cmd.global || frame.frameControl.manufacturerSpecific === !!cmd.manufacturerId)
       && (cmd.global || !frame.frameControl.manufacturerSpecific
-        || frame.manufacturerId === cmd.manufacturerId))
+        || frame.manufacturerId === cmd.manufacturerId));
+
+    // Try to filter based on frame direction, note: this is optional as a cluster command
+    // does not always have a 'direction' property. The filter ensure that multiple commands
+    // can share the same command id. If so, it is required to add the direction property
+    // to both command definitions (see iasZone.js as an example). Cluster.js only receives
+    // frames with directionToClient=true. BoundCluster.js receives frames with
+    // directionToClient=false.
+    filteredCommands = filteredCommands.filter(command => {
+      // Only filter commands that have a direction string property
+      if (typeof command.direction === 'string') {
+        // Filter out commands marked as DIRECTION_CLIENT_TO_SERVER when
+        // frameControl.directionToClient = true
+        if (frame.frameControl.directionToClient
+          && command.direction === Cluster.DIRECTION_CLIENT_TO_SERVER) {
+          return false;
+        }
+      }
+      return true;
+    });
+
+    // Sort and pop the selected command from the array
+    const command = filteredCommands
       .sort((a, b) => (a.isResponse ? 1 : 0) - (b.isResponse ? 1 : 0))
       .pop();
 

--- a/lib/clusters/iasZone.js
+++ b/lib/clusters/iasZone.js
@@ -49,13 +49,59 @@ const ATTRIBUTES = {
 
 const COMMANDS = {
   zoneStatusChangeNotification: {
-    id: 0,
+    id: 0x00,
+    // Add direction property as "zoneEnrollResponse" has same command id.
+    direction: Cluster.DIRECTION_SERVER_TO_CLIENT,
     args: {
       zoneStatus: ZONE_STATUS_DATA_TYPE,
       extendedStatus: ZCLDataTypes.uint8,
       zoneId: ZCLDataTypes.uint8,
       delay: ZCLDataTypes.uint16,
     },
+  },
+  zoneEnrollResponse: {
+    id: 0x00,
+    // Add direction property as "zoneStatusChangeNotification" has same command id.
+    direction: Cluster.DIRECTION_CLIENT_TO_SERVER,
+    args: {
+      enrollResponseCode: ZCLDataTypes.enum8({
+        success: 0x00,
+        notSupported: 0x01,
+        noEnrollPermit: 0x02,
+        tooManyZones: 0x03,
+      }),
+      zoneId: ZCLDataTypes.uint8,
+    },
+  },
+  zoneEnrollRequest: {
+    id: 0x01,
+    // Add direction property as "initiateNormalOperationMode" has same command id.
+    direction: Cluster.DIRECTION_SERVER_TO_CLIENT,
+    args: {
+      zoneType: ZCLDataTypes.enum16({
+        standard: 0x0000,
+        motionSensor: 0x000d,
+        contactSwitch: 0x0015,
+        fireSensor: 0x0028,
+        waterSensor: 0x002a,
+        carbonMonoxideSensor: 0x002b,
+        personalEmergencyDevice: 0x002c,
+        vibrationMovementSensor: 0x002d,
+        remoteControl: 0x010f,
+        keyFob: 0x0115,
+        keyPad: 0x021d,
+        standardWarningDevice: 0x0225,
+        glassBreakSensor: 0x0226,
+        securityRepeater: 0x0229,
+        invalid: 0xffff,
+      }),
+      manufacturerCode: ZCLDataTypes.uint16,
+    },
+  },
+  initiateNormalOperationMode: {
+    id: 0x01,
+    // Add direction property as "zoneEnrollRequest" has same command id.
+    direction: Cluster.DIRECTION_CLIENT_TO_SERVER,
   },
 };
 

--- a/test/iasZone.js
+++ b/test/iasZone.js
@@ -1,0 +1,101 @@
+// eslint-disable-next-line max-classes-per-file,lines-around-directive
+'use strict';
+
+const assert = require('assert');
+const BoundCluster = require('../lib/BoundCluster');
+const IASZoneCluster = require('../lib/clusters/iasZone');
+const Node = require('../lib/Node');
+const { ZCLStandardHeader } = require('../lib/zclFrames');
+
+const endpointId = 1;
+
+describe('IAS Zone', function() {
+  it('should receive onZoneEnrollRequest', function(done) {
+    const node = new Node({
+      sendFrame: () => null,
+      endpointDescriptors: [{
+        endpointId,
+        inputClusters: [IASZoneCluster.ID],
+      }],
+    });
+
+    // Listen for incoming zoneEnrollRequest command
+    node.endpoints[endpointId].clusters.iasZone.onZoneEnrollRequest = data => {
+      assert.strictEqual(data.zoneType, 'keyPad');
+      assert.strictEqual(data.manufacturerCode, 4117);
+      done();
+    };
+
+    // Create zoneEnrollRequest command
+    const frame = new ZCLStandardHeader();
+    frame.cmdId = IASZoneCluster.COMMANDS.zoneEnrollRequest.id;
+    frame.frameControl.directionToClient = true;
+    frame.frameControl.clusterSpecific = true;
+    frame.data = Buffer.from([0x1d, 0x02, 0x15, 0x10]);
+
+    // Feed frame to node
+    node.handleFrame(endpointId, IASZoneCluster.ID, frame.toBuffer(), {});
+  });
+
+  it('should send zoneEnrollResponse', function(done) {
+    const node = new Node({
+      sendFrame: () => null,
+      endpointDescriptors: [{
+        endpointId,
+        inputClusters: [IASZoneCluster.ID],
+      }],
+    });
+
+    // Listen for incoming zoneEnrollRequest command on bound cluster
+    node.endpoints[endpointId].bind(
+      IASZoneCluster.NAME,
+      new (class extends BoundCluster {
+
+        async zoneEnrollResponse(data) {
+          assert.strictEqual(data.enrollResponseCode, 'success');
+          assert.strictEqual(data.zoneId, 10);
+          done();
+        }
+
+      })(),
+    );
+    // Zone enroll response
+    const frame = new ZCLStandardHeader();
+    frame.cmdId = IASZoneCluster.COMMANDS.zoneEnrollResponse.id;
+    frame.frameControl.directionToClient = false;
+    frame.frameControl.clusterSpecific = true;
+    frame.data = Buffer.from([0x00, 0x0a]);
+
+    // Feed frame to node
+    node.handleFrame(endpointId, IASZoneCluster.ID, frame.toBuffer(), {});
+  });
+
+  it('should receive zoneStatusChangeNotification', function(done) {
+    const node = new Node({
+      sendFrame: () => null,
+      endpointDescriptors: [{
+        endpointId,
+        inputClusters: [IASZoneCluster.ID],
+      }],
+    });
+
+    // Listen for incoming zoneEnrollRequest command
+    node.endpoints[endpointId].clusters.iasZone.onZoneStatusChangeNotification = data => {
+      assert.strictEqual(data.zoneStatus.supervisionReports, true);
+      assert.strictEqual(data.extendedStatus, 0);
+      assert.strictEqual(data.zoneId, 10);
+      assert.strictEqual(data.delay, 108);
+      done();
+    };
+
+    // Create zoneStatusChangeNotification command
+    const frame = new ZCLStandardHeader();
+    frame.cmdId = IASZoneCluster.COMMANDS.zoneStatusChangeNotification.id;
+    frame.frameControl.directionToClient = true;
+    frame.frameControl.clusterSpecific = true;
+    frame.data = Buffer.from([0x10, 0x00, 0x00, 0x0A, 0x6C, 0x00]);
+
+    // Feed frame to node
+    node.handleFrame(endpointId, IASZoneCluster.ID, frame.toBuffer(), {});
+  });
+});


### PR DESCRIPTION
This is needed when two commands on the same cluster have identical IDs but different directions.