### PR TITLE
Improve ZCLNodeCluster typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,3 +1,5 @@
+import EventEmitter from "events";
+
 type EndpointDescriptor = {
   endpointId: number;
   inputClusters: number[];
@@ -8,8 +10,9 @@ type ConstructorOptions = {
   endpointDescriptors: EndpointDescriptor[];
   sendFrame: (endpointId: number, clusterId: number, frame: Buffer) => Promise<void>;
 };
-type ZCLNodeCluster = {
-  readAttributes: (...args: string[]) => Promise<void>;
+type ZCLNodeCluster = EventEmitter & {
+  readAttributes: (...attributeNames: string[]) => Promise<{ [attributeName: string]: any }>;
+  writeAttributes: (attributes: { [attributeName: string]: any }) => Promise<{ [attributeName: string]: { id: number, status: 'SUCCESS' | 'FAILURE' } }>;
 };
 type ZCLNodeEndpoint = {
   clusters: { [clusterName: string]: ZCLNodeCluster };


### PR DESCRIPTION
Small fix for the ZCLNodeCluster typing. It now extends the EventEmitter so the `.on()` listeners are recognized (used for `attr.<attributename>` reporting) and the read/write attributes now return fully typed objects. 