### PR TITLE
Fix pressureMeasurement cluster attribute definition

### DIFF
--- a/lib/clusters/pressureMeasurement.js
+++ b/lib/clusters/pressureMeasurement.js
@@ -4,9 +4,9 @@ const Cluster = require('../Cluster');
 const { ZCLDataTypes } = require('../zclTypes');
 
 const ATTRIBUTES = {
-  measuredValue: { id: 0, type: ZCLDataTypes.uint16 },
-  minMeasuredValue: { id: 1, type: ZCLDataTypes.uint16 },
-  maxMeasuredValue: { id: 2, type: ZCLDataTypes.uint16 },
+  measuredValue: { id: 0, type: ZCLDataTypes.int16 },
+  minMeasuredValue: { id: 1, type: ZCLDataTypes.int16 },
+  maxMeasuredValue: { id: 2, type: ZCLDataTypes.int16 },
   tolerance: { id: 3, type: ZCLDataTypes.uint16 },
   scaledValue: { id: 16, type: ZCLDataTypes.int16 },
   minScaledValue: { id: 17, type: ZCLDataTypes.int16 },


### PR DESCRIPTION
As per spec, it should be a signed int.

<img width="606" alt="image" src="https://user-images.githubusercontent.com/1835343/227953505-3b5d13aa-8e54-41bc-83b0-27ab09a763e2.png">
