### PR TITLE
Fix named exports when used

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ const _debug = require('debug');
 
 const ZCLNode = require('./lib/Node');
 const Cluster = require('./lib/Cluster');
-const Clusters = require('./lib/clusters');
 const BoundCluster = require('./lib/BoundCluster');
 const zclTypes = require('./lib/zclTypes');
 const zclFrames = require('./lib/zclFrames');
@@ -47,9 +46,63 @@ const {
 
 const { ZIGBEE_PROFILE_ID, ZIGBEE_DEVICE_ID, IAS_ZONE_TYPE } = require('./lib/constants');
 
+// Required for compatibility with named exports when used with ESM
+const {
+  BasicCluster,
+  PowerConfigurationCluster,
+  DeviceTemperatureCluster,
+  IdentifyCluster,
+  GroupsCluster,
+  ScenesCluster,
+  OnOffCluster,
+  OnOffSwitchCluster,
+  LevelControlCluster,
+  AlarmsCluster,
+  TimeCluster,
+  AnalogInputCluster,
+  AnalogOutputCluster,
+  AnalogValueCluster,
+  BinaryInputCluster,
+  BinaryOutputCluster,
+  BinaryValueCluster,
+  MultistateInputCluster,
+  MultistateOutputCluster,
+  MultistateValueCluster,
+  OTACluster,
+  PowerProfileCluster,
+  PollControlCluster,
+  ShadeConfigurationCluster,
+  DoorLockCluster,
+  WindowCoveringCluster,
+  ThermostatCluster,
+  PumpConfigurationAndControlCluster,
+  FanControlCluster,
+  DehumidificationControlCluster,
+  ColorControlCluster,
+  BallastConfigurationCluster,
+  IlluminanceMeasurementCluster,
+  IlluminanceLevelSensingCluster,
+  TemperatureMeasurementCluster,
+  PressureMeasurementCluster,
+  FlowMeasurementCluster,
+  RelativeHumidityCluster,
+  OccupancySensingCluster,
+  IASZoneCluster,
+  IASACECluster,
+  IASWDCluster,
+  MeteringCluster,
+  ElectricalMeasurementCluster,
+  DiagnosticsCluster,
+  TouchLinkCluster,
+  CLUSTER,
+} = require('./lib/clusters');
+
 module.exports = {
+  // Cluster base classes
   Cluster,
   BoundCluster,
+
+  // ZCL
   ZCLNode,
   zclTypes,
   zclFrames,
@@ -57,7 +110,59 @@ module.exports = {
   ZCLDataType,
   ZCLStruct,
   ZCLError,
-  ...Clusters,
+
+  // Cluster definitions
+  BasicCluster,
+  PowerConfigurationCluster,
+  DeviceTemperatureCluster,
+  IdentifyCluster,
+  GroupsCluster,
+  ScenesCluster,
+  OnOffCluster,
+  OnOffSwitchCluster,
+  LevelControlCluster,
+  AlarmsCluster,
+  TimeCluster,
+  AnalogInputCluster,
+  AnalogOutputCluster,
+  AnalogValueCluster,
+  BinaryInputCluster,
+  BinaryOutputCluster,
+  BinaryValueCluster,
+  MultistateInputCluster,
+  MultistateOutputCluster,
+  MultistateValueCluster,
+  OTACluster,
+  PowerProfileCluster,
+  PollControlCluster,
+  ShadeConfigurationCluster,
+  DoorLockCluster,
+  WindowCoveringCluster,
+  ThermostatCluster,
+  PumpConfigurationAndControlCluster,
+  FanControlCluster,
+  DehumidificationControlCluster,
+  ColorControlCluster,
+  BallastConfigurationCluster,
+  IlluminanceMeasurementCluster,
+  IlluminanceLevelSensingCluster,
+  TemperatureMeasurementCluster,
+  PressureMeasurementCluster,
+  FlowMeasurementCluster,
+  RelativeHumidityCluster,
+  OccupancySensingCluster,
+  IASZoneCluster,
+  IASACECluster,
+  IASWDCluster,
+  MeteringCluster,
+  ElectricalMeasurementCluster,
+  DiagnosticsCluster,
+  TouchLinkCluster,
+
+  // Constant cluster definitions
+  CLUSTER,
+
+  // Utilities
   debug,
   ZIGBEE_PROFILE_ID,
   ZIGBEE_DEVICE_ID,

--- a/lib/clusters/index.js
+++ b/lib/clusters/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-const Cluster = require('../Cluster');
 const BasicCluster = require('./basic');
 const PowerConfigurationCluster = require('./powerConfiguration');
 const DeviceTemperatureCluster = require('./deviceTemperature');
@@ -66,7 +65,6 @@ function destructConstProps({
 }
 
 module.exports = {
-  Cluster,
   BasicCluster, // 0
   PowerConfigurationCluster, // 1
   DeviceTemperatureCluster, // 2


### PR DESCRIPTION
When this library is used in an ESM app, the following error can be thrown:

 ```
× App Crashed. Stack Trace:
× Named export 'CLUSTER' not found. The requested module 'zigbee-clusters' is a CommonJS module, which may not support all module.exports as named exports.
CommonJS modules can always be imported via the default export, for example using:

import pkg from 'zigbee-clusters';
const { debug, Cluster, CLUSTER } = pkg;
```

This is due to how the named exports have been defined:

https://github.com/athombv/node-zigbee-clusters/blob/6ab6b62dfb3eb2157970e53b586e6254558a415d/index.js#L60

[NodeJS](https://nodejs.org/api/esm.html#import-statements) on named imports from CommonJS:

> When importing [CommonJS modules](https://nodejs.org/api/esm.html#commonjs-namespaces), the module.exports object is provided as the default export. Named exports may be available, provided by static analysis as a convenience for better ecosystem compatibility.
>
> CommonJS modules consist of a module.exports object which can be of any type.
>
> To support this, when importing CommonJS from an ECMAScript module, a namespace wrapper for the CommonJS module is constructed, which always provides a default export key pointing to the CommonJS module.exports value.
>
> In addition, a heuristic static analysis is performed against the source text of the CommonJS module to get a best-effort static list of exports to provide on the namespace from values on module.exports. This is necessary since these namespaces must be constructed prior to the evaluation of the CJS module.

By replacing the problematic spread operator with an object destruction action on the original require to add all imports fully named to the `module.exports`, we help the heuristic static analysis and prevent issues with named imports in ESM.