### PR TITLE
ci: drop GitHub Packages registry config from workflows

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -60,15 +60,12 @@ jobs:
         with:
           node-version: 16
           # Needed for publishing to npm
-          registry-url: https://npm.pkg.github.com
 
       # Run `npm ci && npm run build` to re-create your local environment (make sure to commit your - package-lock.json!).
       - name: Build
         run: |
           npm ci
           npm run build
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.HOMEY_GITHUB_ACTIONS_BOT_PERSONAL_ACCESS_TOKEN }}
 
       - name: Version bump patch
         if: github.event.inputs.versionBumpType == 'patch' || contains(github.event.head_commit.message, '#patch') && !contains(github.event.head_commit.message, '#minor') && !contains(github.event.head_commit.message, '#major')
@@ -76,8 +73,6 @@ jobs:
           npm version patch
           git pull
           git push --follow-tags
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.HOMEY_GITHUB_ACTIONS_BOT_PERSONAL_ACCESS_TOKEN }}
 
       - name: Version bump minor
         if: github.event.inputs.versionBumpType == 'minor' || contains(github.event.head_commit.message, '#minor') && !contains(github.event.head_commit.message, '#major')

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -33,15 +33,12 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: 16
-        registry-url: https://npm.pkg.github.com
 
       # Build
     - name: Build
       run: |
         npm ci
         npm run build
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.HOMEY_GITHUB_ACTIONS_BOT_PERSONAL_ACCESS_TOKEN }}
 
     # Deploy
     - name: Deploy To GitHub Pages

--- a/.github/workflows/generate-types.yml
+++ b/.github/workflows/generate-types.yml
@@ -31,12 +31,9 @@ jobs:
         with:
           node-version: "20"
           cache: "npm"
-          registry-url: "https://npm.pkg.github.com"
 
       - name: Install dependencies
         run: npm ci
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.HOMEY_GITHUB_ACTIONS_BOT_PERSONAL_ACCESS_TOKEN }}
 
       - name: Generate TypeScript types
         run: npm run generate-types

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,12 +28,9 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 16
-          registry-url: https://npm.pkg.github.com
 
       # Run `npm ci` to re-create your local environment (make sure to commit your package-lock.json!).
       # Finally run `npm run lint` (make sure you have defined a lint command in package.json e.g. "lint": "eslint .").
       - run: npm ci
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.HOMEY_GITHUB_ACTIONS_BOT_PERSONAL_ACCESS_TOKEN }}
 
       - run: npm run lint

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,12 +28,9 @@ jobs:
       - uses: actions/setup-node@v1
         with:
           node-version: 16 # Important: use the matrix.node property when using a matrix strategy
-          registry-url: https://npm.pkg.github.com
 
       # Run `npm ci` to re-create your local environment (make sure to commit your package-lock.json!).
       # Finally run `npm test` (make sure you have defined a proper test command in package.json).
       - run: npm ci
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.HOMEY_GITHUB_ACTIONS_BOT_PERSONAL_ACCESS_TOKEN }}
 
       - run: npm test


### PR DESCRIPTION
Follow-up to the merged `@athombv/jsdoc-template` 1.7.0 bump. The dev-dependency now lives on npmjs.org, so the legacy GitHub Packages registry-url + `NODE_AUTH_TOKEN` bot-token references in the workflows are unused. They also cause `npm ci` to fail on older Node versions whose npm respects the `@athombv` scope mapping over the lockfile's resolved npmjs.org URL.

The `npm publish` step in `deploy.yml` authenticates via `npm set //registry.npmjs.org/:_authToken \${NPM_AUTH_TOKEN}` further down the workflow, so this change does not affect publishing.