### PR TITLE
fix(types): Repair generate-types after Cluster export removal

### DIFF
--- a/scripts/generate-types.mts
+++ b/scripts/generate-types.mts
@@ -80,7 +80,9 @@ async function main(): Promise<void> {
 
   for (const [key, value] of Object.entries(clustersModule.default.CLUSTER)) {
     const definition = value as {ID: number, NAME: string};
-    const clusterClass = clustersModule.default.Cluster.clusters[definition.ID];
+    // `lib/clusters/index.js` no longer re-exports `Cluster` (PR #182), so
+    // reach the static `Cluster.clusters` registry via the top-level entry.
+    const clusterClass = topModule.Cluster.clusters[definition.ID];
     let clusterName = clusterClass.name;
     // Class names are inconsistent
     if (clusterName === 'TouchlinkCluster') {

--- a/scripts/template.d.ts.txt
+++ b/scripts/template.d.ts.txt
@@ -592,6 +592,17 @@ declare module 'zigbee-clusters' {
       },
     ) => Promise<void>;
 
+    type BoundClusterInterface<Commands extends CommandDefinitions> = {
+      [name in keyof Commands]?: (
+        args: {
+          [arg in keyof Commands[name]['args']]: FromZCLDataType<Commands[name]['args'][arg]>;
+        },
+        meta: object,
+        frame: object,
+        rawFrame: Buffer,
+      ) => unknown | Promise<unknown>
+    }
+
     type AttributeReportingConfiguration<AttributeKey extends string> = {
       [attribute in AttributeKey]: {
         minInterval?: number,


### PR DESCRIPTION
The **Generate TypeScript Types** workflow has been failing on `master` since #181 merged ([failing run](https://github.com/athombv/node-zigbee-clusters/actions/runs/26085099923/job/76696084639)).

## Root cause

Two recently-merged PRs interact badly:

- **#182** ([b799858](https://github.com/athombv/node-zigbee-clusters/commit/b799858)) removed `Cluster` from `lib/clusters/index.js` exports because the base class doesn't belong in a file dedicated to named cluster exports.
- **#181** added `scripts/generate-types.mts`, which on line 83 reaches the shared registry via:
  ```ts
  const clusterClass = clustersModule.default.Cluster.clusters[definition.ID];
  ```

Both PRs were green on their own branches because they didn't yet see each other's state. After the #181 merge, `clustersModule.default.Cluster` is `undefined` -> `TypeError: Cannot read properties of undefined (reading 'clusters')`.

## Fix

`Cluster.clusters` is a singleton static registry attached to the class itself; the path you reach the class through doesn't matter. The script already imports the top-level package entry as `topModule` for `topModule.ZCLDataTypes`, and `index.js` still exports `Cluster`, so the lookup just needs to go through there:

```diff
-    const clusterClass = clustersModule.default.Cluster.clusters[definition.ID];
+    const clusterClass = topModule.Cluster.clusters[definition.ID];
```

This avoids re-introducing the export PR #182 deliberately removed.

## Drive-by template fix

While regenerating `index.d.ts` locally to verify, noticed the script's output didn't match the committed file: commit [05332d1](https://github.com/athombv/node-zigbee-clusters/commit/05332d1) (\"feat(types): add type definition for BoundCluster\") added the `BoundClusterInterface` utility type directly to `index.d.ts` but forgot to add it to `scripts/template.d.ts.txt`. Without backporting it, the next workflow-driven regeneration would silently drop that public type. Added it to the template so the generated output stays stable.

## Verification

On Node 24 locally:

| Check | Result |
|-|-|
| `npm run generate-types` | success |
| `npx tsc --noEmit index.d.ts` | clean |
| Regenerated `index.d.ts` vs committed | no drift |
| `npm run lint` | pass |
| `npm test` | 76/76 pass |

Once this lands, the Generate TypeScript Types workflow should go green on master and the auto-commit step becomes a no-op (since the template now reflects the committed `index.d.ts`).