### PR TITLE
ci: Fix stale paths filter on generate-types workflow

### DIFF
--- a/.github/workflows/generate-types.yml
+++ b/.github/workflows/generate-types.yml
@@ -7,8 +7,10 @@ on:
       - testing
     paths:
       - "lib/clusters/**/*.js"
-      - "scripts/generate-types.js"
+      - "scripts/generate-types.mts"
+      - "scripts/template.d.ts.txt"
       - "index.js"
+      - "lib/Cluster.js"
       - "lib/constants.js"
   workflow_dispatch:
 


### PR DESCRIPTION
The `paths:` trigger filter on the Generate TypeScript Types workflow still references `scripts/generate-types.js`, which was renamed to `.mts` in PR #181. As a result, edits to the generator script (or its template) have stopped triggering the workflow - which masked the post-merge crash fixed in PR #187 until the #181 merge push fired for unrelated reasons.

## Filter changes

```diff
 paths:
   - "lib/clusters/**/*.js"
-  - "scripts/generate-types.js"
+  - "scripts/generate-types.mts"
+  - "scripts/template.d.ts.txt"
   - "index.js"
+  - "lib/Cluster.js"
   - "lib/constants.js"
```

| Path | Why |
|-|-|
| `scripts/generate-types.mts` | Replaces the renamed `.js` reference - script edits should re-trigger regeneration. |
| `scripts/template.d.ts.txt` | The script reads this and splices it into the generated `index.d.ts`. Template-only edits today don't re-run generation, which is exactly how PR #187's `BoundClusterInterface` backport could have silently drifted. |
| `lib/Cluster.js` | Hosts the static `Cluster.clusters` registry the script depends on. Changes to its shape can affect generation correctness. |

No other trigger semantics change.