### PR TITLE
feat(types): Type sendable methods on SERVER_TO_CLIENT commands and allow dynamic on-handler assignment

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -720,6 +720,21 @@ declare module "zigbee-clusters" {
     },
   };
   class OTACluster<Attributes extends types.AttributeDefinitions = OTAClusterAttributes, Commands extends types.CommandDefinitions = OTAClusterCommands> extends Cluster<Attributes, Commands> {
+    imageNotify(
+      args?: {
+        manufacturerId?: number,
+        payloadType?: "queryJitter" | "queryJitterAndManufacturerCode" | "queryJitterAndManufacturerCodeAndImageType" | "queryJitterAndManufacturerCodeAndImageTypeAndNewFileVersion",
+        queryJitter?: number,
+        manufacturerCode?: number,
+        imageType?: number,
+        newFileVersion?: number,
+      },
+      opts?: {
+        waitForResponse?: boolean,
+        timeout?: number,
+        disableDefaultResponse?: boolean,
+      },
+    ): Promise<void>;
     onImageNotify(
       args: {
         payloadType?: "queryJitter" | "queryJitterAndManufacturerCode" | "queryJitterAndManufacturerCodeAndImageType" | "queryJitterAndManufacturerCodeAndImageTypeAndNewFileVersion",
@@ -812,6 +827,26 @@ declare module "zigbee-clusters" {
       requestTime?: number,
       minimumBlockPeriod?: number,
     }>;
+    imageBlockResponse(
+      args?: {
+        manufacturerId?: number,
+        status?: types.ZCLEnum8Status,
+        manufacturerCode?: number,
+        imageType?: number,
+        fileVersion?: number,
+        fileOffset?: number,
+        dataSize?: number,
+        imageData?: Buffer,
+        currentTime?: number,
+        requestTime?: number,
+        minimumBlockPeriod?: number,
+      },
+      opts?: {
+        waitForResponse?: boolean,
+        timeout?: number,
+        disableDefaultResponse?: boolean,
+      },
+    ): Promise<void>;
     onImageBlockResponse(
       args: {
         status?: types.ZCLEnum8Status,
@@ -849,6 +884,21 @@ declare module "zigbee-clusters" {
       currentTime: number,
       upgradeTime: number,
     }>;
+    upgradeEndResponse(
+      args?: {
+        manufacturerId?: number,
+        manufacturerCode?: number,
+        imageType?: number,
+        fileVersion?: number,
+        currentTime?: number,
+        upgradeTime?: number,
+      },
+      opts?: {
+        waitForResponse?: boolean,
+        timeout?: number,
+        disableDefaultResponse?: boolean,
+      },
+    ): Promise<void>;
     onUpgradeEndResponse(
       args: {
         manufacturerCode?: number,
@@ -1526,6 +1576,22 @@ declare module "zigbee-clusters" {
     ): Promise<{
       status: number,
     }>;
+    operationEventNotification(
+      args?: {
+        manufacturerId?: number,
+        operationEventSource?: number,
+        operationEventCode?: number,
+        userId?: number,
+        pin?: Buffer,
+        zigBeeLocalTime?: number,
+        data?: Buffer,
+      },
+      opts?: {
+        waitForResponse?: boolean,
+        timeout?: number,
+        disableDefaultResponse?: boolean,
+      },
+    ): Promise<void>;
     onOperationEventNotification(
       args: {
         operationEventSource?: number,
@@ -1538,6 +1604,24 @@ declare module "zigbee-clusters" {
       meta: object,
       frame: object,
       rawFrame: Buffer,
+    ): Promise<void>;
+    programmingEventNotification(
+      args?: {
+        manufacturerId?: number,
+        programEventSource?: number,
+        programEventCode?: number,
+        userId?: number,
+        pin?: Buffer,
+        userType?: "unrestricted" | "yearDayScheduleUser" | "weekDayScheduleUser" | "masterUser" | "nonAccessUser" | "notSupported",
+        userStatus?: "available" | "occupiedEnabled" | "occupiedDisabled" | "notSupported",
+        zigBeeLocalTime?: number,
+        data?: Buffer,
+      },
+      opts?: {
+        waitForResponse?: boolean,
+        timeout?: number,
+        disableDefaultResponse?: boolean,
+      },
     ): Promise<void>;
     onProgrammingEventNotification(
       args: {
@@ -1962,6 +2046,20 @@ declare module "zigbee-clusters" {
     initiateNormalOperationMode: { id: 0x01, direction: "DIRECTION_CLIENT_TO_SERVER" },
   };
   class IASZoneCluster<Attributes extends types.AttributeDefinitions = IASZoneClusterAttributes, Commands extends types.CommandDefinitions = IASZoneClusterCommands> extends Cluster<Attributes, Commands> {
+    zoneStatusChangeNotification(
+      args?: {
+        manufacturerId?: number,
+        zoneStatus?: Bitmap<"alarm1" | "alarm2" | "tamper" | "battery" | "supervisionReports" | "restoreReports" | "trouble" | "acMains" | "test" | "batteryDefect">,
+        extendedStatus?: number,
+        zoneId?: number,
+        delay?: number,
+      },
+      opts?: {
+        waitForResponse?: boolean,
+        timeout?: number,
+        disableDefaultResponse?: boolean,
+      },
+    ): Promise<void>;
     onZoneStatusChangeNotification(
       args: {
         zoneStatus?: Bitmap<"alarm1" | "alarm2" | "tamper" | "battery" | "supervisionReports" | "restoreReports" | "trouble" | "acMains" | "test" | "batteryDefect">,
@@ -1978,6 +2076,18 @@ declare module "zigbee-clusters" {
         manufacturerId?: number,
         enrollResponseCode?: "success" | "notSupported" | "noEnrollPermit" | "tooManyZones",
         zoneId?: number,
+      },
+      opts?: {
+        waitForResponse?: boolean,
+        timeout?: number,
+        disableDefaultResponse?: boolean,
+      },
+    ): Promise<void>;
+    zoneEnrollRequest(
+      args?: {
+        manufacturerId?: number,
+        zoneType?: "standardCIE" | "motionSensor" | "contactSwitch" | "doorWindowHandle" | "fireSensor" | "waterSensor" | "carbonMonoxideSensor" | "personalEmergencyDevice" | "vibrationMovementSensor" | "remoteControl" | "keyFob" | "keypad" | "standardWarningDevice" | "glassBreakSensor" | "securityRepeater" | "invalidZoneType",
+        manufacturerCode?: number,
       },
       opts?: {
         waitForResponse?: boolean,
@@ -2737,6 +2847,17 @@ declare module "zigbee-clusters" {
 
     discoverCommandsGenerated({startValue, maxResults}?: {startValue?: number, maxResults?: number}, opts?: {timeout?: number}): Promise<Array<number>>;
     discoverCommandsReceived({startValue, maxResults}?: {startValue?: number, maxResults?: number}, opts?: {timeout?: number}): Promise<Array<number>>;
+
+    /**
+     * Receive-side command handler slot. The dispatch loop in `handleFrame`
+     * resolves incoming commands via `this[\`on\${CommandName}\`]`, so callers
+     * install handlers by assigning to a property like `cluster.onImageNotify`
+     * (or `delete cluster.onImageNotify` to remove). Subclasses that declare
+     * a specific `on<Name>` method (e.g. the generated cluster classes) keep
+     * their typed signature - this index signature only kicks in for keys
+     * that aren't otherwise declared.
+     */
+    [handlerKey: `on${Capitalize<string>}`]: ((...args: any[]) => unknown) | undefined;
 
     readAttributes<K extends keyof (Attributes & types.GLOBAL_ATTRIBUTES) | number>(attributes: ReadonlyArray<K>, opts?: {timeout?: number}): Promise<{[attribute in K]: types.AttributesFromDefinition<Attributes & types.GLOBAL_ATTRIBUTES>[attribute]}>;
     writeAttributes<K extends keyof (Attributes & types.GLOBAL_ATTRIBUTES)>(attributes: {[attribute in K]: types.AttributesFromDefinition<Attributes & types.GLOBAL_ATTRIBUTES>[attribute]}, opts?: {timeout?: number}): Promise<{[attribute in K]: {id: number, status: 'SUCCESS' | 'FAILURE'}}>

--- a/index.d.ts
+++ b/index.d.ts
@@ -2626,6 +2626,53 @@ declare module "zigbee-clusters" {
       COMMANDS: Readonly<TouchLinkClusterCommands>,
     },
   };
+  type ClustersByName = {
+    "basic"?: BasicCluster;
+    "powerConfiguration"?: PowerConfigurationCluster;
+    "deviceTemperature"?: DeviceTemperatureCluster;
+    "identify"?: IdentifyCluster;
+    "groups"?: GroupsCluster;
+    "scenes"?: ScenesCluster;
+    "onOff"?: OnOffCluster;
+    "onOffSwitch"?: OnOffSwitchCluster;
+    "levelControl"?: LevelControlCluster;
+    "alarms"?: AlarmsCluster;
+    "time"?: TimeCluster;
+    "analogInput"?: AnalogInputCluster;
+    "analogOutput"?: AnalogOutputCluster;
+    "analogValue"?: AnalogValueCluster;
+    "binaryInput"?: BinaryInputCluster;
+    "binaryOutput"?: BinaryOutputCluster;
+    "binaryValue"?: BinaryValueCluster;
+    "multistateInput"?: MultistateInputCluster;
+    "multistateOutput"?: MultistateOutputCluster;
+    "multistateValue"?: MultistateValueCluster;
+    "ota"?: OTACluster;
+    "powerProfile"?: PowerProfileCluster;
+    "pollControl"?: PollControlCluster;
+    "shadeConfiguration"?: ShadeConfigurationCluster;
+    "doorLock"?: DoorLockCluster;
+    "windowCovering"?: WindowCoveringCluster;
+    "thermostat"?: ThermostatCluster;
+    "pumpConfigurationAndControl"?: PumpConfigurationAndControlCluster;
+    "fanControl"?: FanControlCluster;
+    "colorControl"?: ColorControlCluster;
+    "ballastConfiguration"?: BallastConfigurationCluster;
+    "illuminanceMeasurement"?: IlluminanceMeasurementCluster;
+    "illuminanceLevelSensing"?: IlluminanceLevelSensingCluster;
+    "temperatureMeasurement"?: TemperatureMeasurementCluster;
+    "pressureMeasurement"?: PressureMeasurementCluster;
+    "flowMeasurement"?: FlowMeasurementCluster;
+    "relativeHumidity"?: RelativeHumidityCluster;
+    "occupancySensing"?: OccupancySensingCluster;
+    "iasZone"?: IASZoneCluster;
+    "iasACE"?: IASACECluster;
+    "iasWD"?: IASWDCluster;
+    "metering"?: MeteringCluster;
+    "electricalMeasurement"?: ElectricalMeasurementCluster;
+    "diagnostics"?: DiagnosticsCluster;
+    "touchlink"?: TouchLinkCluster;
+  };
 
   import {EventEmitter} from "events";
 
@@ -2686,7 +2733,11 @@ declare module "zigbee-clusters" {
       inputClusters: number[];
       outputClusters: number[];
     }[]);
-    clusters: Record<string, Cluster<any, any>>;
+    // Typed lookup: known cluster names (per the generated `ClustersByName`)
+    // resolve to their specific class (e.g. `clusters.onOff` is `OnOffCluster`),
+    // while unknown keys fall back to the generic Cluster via the index half.
+    // All known keys are optional - an endpoint may not implement every cluster.
+    clusters: ClustersByName & Record<string, Cluster<any, any>>;
     bindings: Record<string, BoundCluster>;
 
     bind(clusterName: string, clusterImpl: BoundCluster): void;

--- a/scripts/generate-types.mts
+++ b/scripts/generate-types.mts
@@ -78,6 +78,11 @@ async function main(): Promise<void> {
   stringBuilder.printLine("const CLUSTER: {");
   stringBuilder.increaseIndent();
 
+  // Collect (NAME, ClassName) pairs to emit a typed lookup map after the
+  // CLUSTER block — used by `ZCLNodeEndpoint.clusters` so consumers get
+  // typed access (e.g. `endpoint.clusters.onOff` is `OnOffCluster`).
+  const clusterClassByName: Array<{ name: string; className: string }> = [];
+
   for (const [key, value] of Object.entries(clustersModule.default.CLUSTER)) {
     const definition = value as {ID: number, NAME: string};
     // `lib/clusters/index.js` no longer re-exports `Cluster` (PR #182), so
@@ -91,6 +96,7 @@ async function main(): Promise<void> {
     if (!clusterName.endsWith("Cluster")) {
       clusterName = `${clusterName}Cluster`;
     }
+    clusterClassByName.push({ name: definition.NAME, className: clusterName });
     stringBuilder.printLine(`${key}: {`);
     stringBuilder.increaseIndent();
     stringBuilder.printLine(`ID: 0x${definition.ID.toString(16).padStart(4, "0")},`);
@@ -102,6 +108,19 @@ async function main(): Promise<void> {
   }
 
   // Close CLUSTER
+  stringBuilder.decreaseIndent();
+  stringBuilder.printLine("};");
+
+  // Emit a name->class lookup map used by `ZCLNodeEndpoint.clusters` for
+  // typed access to known cluster classes. Keys are optional because an
+  // endpoint may not implement every cluster; an unknown cluster name
+  // (e.g. manufacturer-specific) falls through the intersection with
+  // `Record<string, Cluster<any, any>>` in the template.
+  stringBuilder.printLine("type ClustersByName = {");
+  stringBuilder.increaseIndent();
+  for (const { name, className } of clusterClassByName) {
+    stringBuilder.printLine(`${JSON.stringify(name)}?: ${className};`);
+  }
   stringBuilder.decreaseIndent();
   stringBuilder.printLine("};");
 

--- a/scripts/generate-types.mts
+++ b/scripts/generate-types.mts
@@ -231,51 +231,76 @@ function formatCommand(stringBuilder: StringBuilder, className: string, name: st
 
 
 function formatCommandMethod(stringBuilder: StringBuilder, className: string, name: string, definition: types.CommandDefinition): void {
-  // Method name
-  stringBuilder.startLine();
+  // The runtime `Cluster.addCluster` installs a sendable method for every
+  // command regardless of direction (see lib/Cluster.js around the
+  // `Object.defineProperty(proto, cmdName, ...)` loop). Emit the sendable
+  // form unconditionally so callers acting in the "sending" role get typed
+  // access (e.g. Homey sending the OTA cluster's `imageNotify` command when
+  // it acts as OTA server). Additionally, for DIRECTION_SERVER_TO_CLIENT
+  // commands, emit the `on<Name>` handler shape used by the dispatch loop
+  // when a frame is received.
+  emitSendableCommandMethod(stringBuilder, className, name, definition);
   if (definition.direction === 'DIRECTION_SERVER_TO_CLIENT') {
-    // Bound cluster
-    stringBuilder.print("on", name.charAt(0).toUpperCase(), name.slice(1));
-  } else {
-    stringBuilder.print(name);
+    emitCommandHandlerMethod(stringBuilder, className, name, definition);
   }
+}
+
+function emitSendableCommandMethod(stringBuilder: StringBuilder, className: string, name: string, definition: types.CommandDefinition): void {
+  stringBuilder.startLine();
+  stringBuilder.print(name);
 
   // Open method
   stringBuilder.print("(");
   stringBuilder.endLine();
   stringBuilder.increaseIndent();
 
-  if (definition.direction === 'DIRECTION_SERVER_TO_CLIENT') {
-    if (definition.args === undefined) {
-      stringBuilder.printLine('args: undefined,')
-    } else {
-      // Open args
-      stringBuilder.printLine('args: {');
-      stringBuilder.increaseIndent();
+  // Open args
+  stringBuilder.startLine();
+  stringBuilder.print('args?: {');
+  stringBuilder.endLine();
+  stringBuilder.increaseIndent();
+  stringBuilder.printLine('manufacturerId?: number,');
 
-      for (const arg in definition.args) {
-        stringBuilder.startLine();
-        stringBuilder.print(`${arg}?: `);
-        formatZCLDataTypeGeneric(stringBuilder, className, name, definition.args[arg]);
-        stringBuilder.print(',');
-        stringBuilder.endLine();
-      }
+  for (const arg in definition.args) {
+    stringBuilder.startLine();
+    stringBuilder.print(`${arg}?: `);
+    formatZCLDataTypeGeneric(stringBuilder, className, name, definition.args[arg]);
+    stringBuilder.print(',');
+    stringBuilder.endLine();
+  }
 
-      // Close args
-      stringBuilder.decreaseIndent();
-      stringBuilder.printLine('},');
-    }
+  // Close args
+  stringBuilder.decreaseIndent();
+  stringBuilder.printLine('},');
 
-    stringBuilder.printLine("meta: object,")
-    stringBuilder.printLine("frame: object,")
-    stringBuilder.printLine("rawFrame: Buffer,")
+
+  // Opts
+  stringBuilder.printLine('opts?: {');
+  stringBuilder.increaseIndent();
+  stringBuilder.printLine('waitForResponse?: boolean,');
+  stringBuilder.printLine('timeout?: number,');
+  stringBuilder.printLine('disableDefaultResponse?: boolean,');
+  stringBuilder.decreaseIndent();
+  stringBuilder.printLine('},');
+
+  closeCommandMethod(stringBuilder, className, name, definition);
+}
+
+function emitCommandHandlerMethod(stringBuilder: StringBuilder, className: string, name: string, definition: types.CommandDefinition): void {
+  stringBuilder.startLine();
+  stringBuilder.print("on", name.charAt(0).toUpperCase(), name.slice(1));
+
+  // Open method
+  stringBuilder.print("(");
+  stringBuilder.endLine();
+  stringBuilder.increaseIndent();
+
+  if (definition.args === undefined) {
+    stringBuilder.printLine('args: undefined,')
   } else {
     // Open args
-    stringBuilder.startLine();
-    stringBuilder.print('args?: {');
-    stringBuilder.endLine();
+    stringBuilder.printLine('args: {');
     stringBuilder.increaseIndent();
-    stringBuilder.printLine('manufacturerId?: number,');
 
     for (const arg in definition.args) {
       stringBuilder.startLine();
@@ -288,18 +313,16 @@ function formatCommandMethod(stringBuilder: StringBuilder, className: string, na
     // Close args
     stringBuilder.decreaseIndent();
     stringBuilder.printLine('},');
-
-
-    // Opts
-    stringBuilder.printLine('opts?: {');
-    stringBuilder.increaseIndent();
-    stringBuilder.printLine('waitForResponse?: boolean,');
-    stringBuilder.printLine('timeout?: number,');
-    stringBuilder.printLine('disableDefaultResponse?: boolean,');
-    stringBuilder.decreaseIndent();
-    stringBuilder.printLine('},');
   }
 
+  stringBuilder.printLine("meta: object,")
+  stringBuilder.printLine("frame: object,")
+  stringBuilder.printLine("rawFrame: Buffer,")
+
+  closeCommandMethod(stringBuilder, className, name, definition);
+}
+
+function closeCommandMethod(stringBuilder: StringBuilder, className: string, name: string, definition: types.CommandDefinition): void {
   // Close method
   stringBuilder.decreaseIndent();
   stringBuilder.startLine();

--- a/scripts/template.d.ts.txt
+++ b/scripts/template.d.ts.txt
@@ -59,7 +59,11 @@ declare module 'zigbee-clusters' {
       inputClusters: number[];
       outputClusters: number[];
     }[]);
-    clusters: Record<string, Cluster<any, any>>;
+    // Typed lookup: known cluster names (per the generated `ClustersByName`)
+    // resolve to their specific class (e.g. `clusters.onOff` is `OnOffCluster`),
+    // while unknown keys fall back to the generic Cluster via the index half.
+    // All known keys are optional - an endpoint may not implement every cluster.
+    clusters: ClustersByName & Record<string, Cluster<any, any>>;
     bindings: Record<string, BoundCluster>;
 
     bind(clusterName: string, clusterImpl: BoundCluster): void;

--- a/scripts/template.d.ts.txt
+++ b/scripts/template.d.ts.txt
@@ -221,6 +221,17 @@ declare module 'zigbee-clusters' {
     discoverCommandsGenerated({startValue, maxResults}?: {startValue?: number, maxResults?: number}, opts?: {timeout?: number}): Promise<Array<number>>;
     discoverCommandsReceived({startValue, maxResults}?: {startValue?: number, maxResults?: number}, opts?: {timeout?: number}): Promise<Array<number>>;
 
+    /**
+     * Receive-side command handler slot. The dispatch loop in `handleFrame`
+     * resolves incoming commands via `this[\`on\${CommandName}\`]`, so callers
+     * install handlers by assigning to a property like `cluster.onImageNotify`
+     * (or `delete cluster.onImageNotify` to remove). Subclasses that declare
+     * a specific `on<Name>` method (e.g. the generated cluster classes) keep
+     * their typed signature - this index signature only kicks in for keys
+     * that aren't otherwise declared.
+     */
+    [handlerKey: `on${Capitalize<string>}`]: ((...args: any[]) => unknown) | undefined;
+
     readAttributes<K extends keyof (Attributes & types.GLOBAL_ATTRIBUTES) | number>(attributes: ReadonlyArray<K>, opts?: {timeout?: number}): Promise<{[attribute in K]: types.AttributesFromDefinition<Attributes & types.GLOBAL_ATTRIBUTES>[attribute]}>;
     writeAttributes<K extends keyof (Attributes & types.GLOBAL_ATTRIBUTES)>(attributes: {[attribute in K]: types.AttributesFromDefinition<Attributes & types.GLOBAL_ATTRIBUTES>[attribute]}, opts?: {timeout?: number}): Promise<{[attribute in K]: {id: number, status: 'SUCCESS' | 'FAILURE'}}>
 


### PR DESCRIPTION
Two related type-surface fixes that resolve the need for consumer-side augmentations after the 3.1 type rewrite (#181):

## 1. Emit sendable `<name>` method for `DIRECTION_SERVER_TO_CLIENT` commands

The 3.1 generator only emits `on<Name>(args, meta, frame, rawFrame)` for `DIRECTION_SERVER_TO_CLIENT` commands. The runtime, however, installs a sendable method for *every* command regardless of direction (see `lib/Cluster.js` around the `Object.defineProperty(proto, cmdName, ...)` loop in `Cluster.addCluster`).

Concretely the OTA cluster declares `imageNotify` with direction `SERVER_TO_CLIENT`. Homey acts as the OTA server and legitimately calls `cluster.imageNotify({...})` to notify clients - that path was untyped in 3.1.

After this change:
- Every command emits the sendable `<name>(args?, opts?): Promise<void>` form (current `CLIENT_TO_SERVER` shape, applied to all directions).
- `SERVER_TO_CLIENT` commands additionally still emit `on<Name>(args, meta, frame, rawFrame): Promise<void>` so receive-side handler typing is preserved.

Refactored `formatCommandMethod` into `emitSendableCommandMethod` + `emitCommandHandlerMethod` + `closeCommandMethod` to avoid duplicating the closing/Promise<...> emission across both shapes.

## 2. Add `on${Capitalize<string>}` index signature to `Cluster`

The receive-side dispatch loop in the runtime resolves incoming commands via `this[\`on\${CommandName}\`]` on the cluster instance. Consumers install handlers by assigning to that key (e.g. homey-core's `BasicZigbeeDevice` does `cluster.onSomething = eventHandler`). Pre-3.1, this worked because the cluster type was loose; in 3.1's stricter `Cluster<Attributes, Commands>` the dynamic assignment isn't allowed.

Adding the index signature exposes the dispatch slot to the typed surface without any runtime change. Subclasses that declare a specific `on<Name>(args, meta, frame, rawFrame)` method retain their typed signature - TypeScript's overload resolution picks the named declaration over the index signature for known keys.

```ts
[handlerKey: \`on\${Capitalize<string>}\`]: ((...args: any[]) => unknown) | undefined;
```

## Out of scope

- **No runtime changes.** Both fixes are pure additions to the generated type surface (script + template). `lib/` is untouched.
- The fork-fix of #181's "removed helper exports" (`ClusterAttributesFromDefinition`, etc.) is **not** included here - consumers that used those helpers (node-homey-os does) can replace them locally; their absence isn't a runtime bug.

## Verified locally

| Check | Result |
|-|-|
| `npm run generate-types` | clean, `imageNotify` (sendable) + `onImageNotify` (handler) both appear |
| `npx tsc --noEmit index.d.ts` | clean |
| `npm run lint` | pass |
| `npm test` | 76/76 pass |

## Why this matters now

Surfaced while adapting `node-homey-os` to consume 3.1.x. Without these fixes, consumers have to:
- Augment every cluster class that has `SERVER_TO_CLIENT` commands they send (e.g. `interface OTACluster { imageNotify(...): Promise<void> }`)
- Augment `Cluster` with a similar index signature

Moving both into the generator + template removes the need for downstream augmentation and is type-safe for any consumer (including hypothetical bound-cluster code in zigbee-clusters itself).