### PR TITLE
fix(cluster): reject truncated command payloads with MALFORMED_COMMAND

### DIFF
--- a/lib/BoundCluster.js
+++ b/lib/BoundCluster.js
@@ -4,6 +4,7 @@ let { debug } = require('./util');
 const { ZCLDataType } = require('./zclTypes');
 const { getLogId, getPropertyDescriptor } = require('./util');
 const Cluster = require('./Cluster');
+const parseCommandArgs = require('./util/parseCommandArgs');
 
 debug = debug.extend('bound-cluster');
 
@@ -308,8 +309,9 @@ class BoundCluster {
       .pop();
 
     if (command) {
+      // Validate payload length before parsing; see lib/util/parseCommandArgs.js.
       const args = command.args
-        ? command.args.fromBuffer(frame.data, 0)
+        ? parseCommandArgs(command, frame.data)
         : undefined;
 
       if (this[command.name]) {

--- a/lib/Cluster.js
+++ b/lib/Cluster.js
@@ -4,6 +4,7 @@ const EventEmitter = require('events');
 
 let { debug } = require('./util');
 const { getLogId } = require('./util');
+const parseCommandArgs = require('./util/parseCommandArgs');
 
 debug = debug.extend('cluster');
 
@@ -775,9 +776,11 @@ class Cluster extends EventEmitter {
     if (command) {
       const handlerName = `on${command.name.charAt(0).toUpperCase()}${command.name.slice(1)}`;
 
-      // Parse the command arguments
+      // Parse the command arguments. Validate the payload length first so that
+      // truncated frames are rejected instead of silently parsed with zero-filled
+      // fields (see lib/util/parseArgs.js for details).
       const args = command.args
-        ? command.args.fromBuffer(frame.data, 0)
+        ? parseCommandArgs(command, frame.data)
         : undefined;
 
       debug(this.logId, 'received frame', command.name, args);

--- a/lib/Cluster.js
+++ b/lib/Cluster.js
@@ -778,7 +778,7 @@ class Cluster extends EventEmitter {
 
       // Parse the command arguments. Validate the payload length first so that
       // truncated frames are rejected instead of silently parsed with zero-filled
-      // fields (see lib/util/parseArgs.js for details).
+      // fields (see lib/util/parseCommandArgs.js for details).
       const args = command.args
         ? parseCommandArgs(command, frame.data)
         : undefined;

--- a/lib/util/parseCommandArgs.js
+++ b/lib/util/parseCommandArgs.js
@@ -1,0 +1,56 @@
+'use strict';
+
+const { ZCLError } = require('./index');
+
+/**
+ * Parse a ZCL command's argument payload with defensive length validation.
+ *
+ * The underlying parser primitives in `@athombv/data-types` silently fall back
+ * to zero-filled values when the source buffer is shorter than the declared
+ * field length. For example, an empty payload parsed against a fixed-size
+ * struct produces an object where every numeric field is 0 and every bitmap
+ * field has all bits clear. This is unsafe for alarm-routing clusters (IAS
+ * Zone) and for status-bearing response frames, where the zero values happen
+ * to mean "all clear" / "SUCCESS".
+ *
+ * This helper rejects truncated payloads up-front by throwing a ZCLError with
+ * status `MALFORMED_COMMAND`, which `Endpoint.handleFrame` converts into a
+ * proper default-response frame back to the sender.
+ *
+ * @param {object} command - Cluster command definition (with `args` Struct).
+ * @param {Buffer} data - Frame payload bytes.
+ * @returns {object} Parsed args instance.
+ * @throws {ZCLError} With zclStatus `MALFORMED_COMMAND` when parsing fails or
+ *   the payload is shorter than the args struct's minimum byte length.
+ */
+function parseCommandArgs(command, data) {
+  const argsType = command.args;
+
+  // Commands declared with `encodeMissingFieldsBehavior: 'skip'` allow trailing
+  // fields to be omitted (e.g. OTA `hardwareVersion` is only present when its
+  // fieldControl bit is set). For those we cannot derive a strict minimum from
+  // the struct definition and rely on the try/catch below to catch overruns.
+  if (command.encodeMissingFieldsBehavior !== 'skip') {
+    // Struct.length convention:
+    //   > 0 : exact byte count for an all-fixed-size struct
+    //   < 0 : negative of the fixed-portion size for a varsize struct
+    //   = 0 : no payload required
+    // For both fixed and varsize structs, |declaredLength| is the minimum
+    // number of bytes the payload must carry to populate the fixed fields.
+    const minLength = Math.abs(argsType.length);
+    if (data.length < minLength) {
+      throw new ZCLError('MALFORMED_COMMAND');
+    }
+  }
+
+  try {
+    return argsType.fromBuffer(data, 0);
+  } catch (err) {
+    // The parser threw mid-walk (e.g. a varsize length prefix overran the
+    // payload). Treat as malformed rather than letting the raw RangeError
+    // propagate as a generic FAILURE.
+    throw new ZCLError('MALFORMED_COMMAND');
+  }
+}
+
+module.exports = parseCommandArgs;

--- a/lib/util/parseCommandArgs.js
+++ b/lib/util/parseCommandArgs.js
@@ -23,24 +23,49 @@ const { ZCLError } = require('./index');
  * @throws {ZCLError} With zclStatus `MALFORMED_COMMAND` when parsing fails or
  *   the payload is shorter than the args struct's minimum byte length.
  */
-function parseCommandArgs(command, data) {
-  const argsType = command.args;
-
-  // Commands declared with `encodeMissingFieldsBehavior: 'skip'` allow trailing
-  // fields to be omitted (e.g. OTA `hardwareVersion` is only present when its
-  // fieldControl bit is set). For those we cannot derive a strict minimum from
-  // the struct definition and rely on the try/catch below to catch overruns.
-  if (command.encodeMissingFieldsBehavior !== 'skip') {
+/**
+ * Minimum payload length we'll accept before invoking the parser.
+ *
+ * For commands declared with `encodeMissingFieldsBehavior: 'skip'`, trailing
+ * fields may be intentionally omitted (e.g. OTA `hardwareVersion` is only
+ * present when its `fieldControl` bit is set). We can't derive the strict
+ * minimum from the struct alone, but every such command in practice has a
+ * mandatory leading discriminator (status, fieldControl, payloadType) that
+ * determines which subsequent fields are present. Without that leading byte,
+ * the parsed result is meaningless; with it, the parser correctly omits
+ * optional trailing fields.
+ *
+ * So for 'skip' commands we require at least the first field's byte width.
+ * For non-'skip' commands we require the full fixed-portion length.
+ *
+ * @param {object} argsType - The ZCLStruct class for this command's args.
+ * @param {boolean} skipMode - Whether the command uses `encodeMissingFieldsBehavior: 'skip'`.
+ * @returns {number} Minimum byte length the payload must carry.
+ */
+function computeMinLength(argsType, skipMode) {
+  if (!skipMode) {
     // Struct.length convention:
     //   > 0 : exact byte count for an all-fixed-size struct
     //   < 0 : negative of the fixed-portion size for a varsize struct
     //   = 0 : no payload required
-    // For both fixed and varsize structs, |declaredLength| is the minimum
-    // number of bytes the payload must carry to populate the fixed fields.
-    const minLength = Math.abs(argsType.length);
-    if (data.length < minLength) {
-      throw new ZCLError('MALFORMED_COMMAND');
-    }
+    return Math.abs(argsType.length);
+  }
+
+  const firstField = Object.values(argsType.fields)[0];
+  if (!firstField) return 0;
+  // Fixed-width field's length is a positive integer; varsize is negative or 0.
+  // For varsize first fields (uncommon for 'skip' commands), require at least
+  // 1 byte so the length prefix is present.
+  return firstField.length > 0 ? firstField.length : 1;
+}
+
+function parseCommandArgs(command, data) {
+  const argsType = command.args;
+  const skipMode = command.encodeMissingFieldsBehavior === 'skip';
+
+  const minLength = computeMinLength(argsType, skipMode);
+  if (data.length < minLength) {
+    throw new ZCLError('MALFORMED_COMMAND');
   }
 
   try {

--- a/lib/zclFrames.js
+++ b/lib/zclFrames.js
@@ -1,6 +1,7 @@
 'use strict';
 
 const { ZCLDataType, ZCLDataTypes, ZCLStruct } = require('./zclTypes');
+const { ZCLError } = require('./util');
 
 const ZCLFrameControlBitmap = ZCLDataTypes.map8('clusterSpecific', null, 'manufacturerSpecific', 'directionToClient', 'disableDefaultResponse');
 
@@ -69,6 +70,16 @@ const ZCLAttributeDataRecord = (withStatus, attributes) => new ZCLDataType(NaN, 
 
       if (attributes[res.id]) {
         res.name = attributes[res.id].name || `unknown_attr_${res.id}`;
+      }
+
+      // Validate that enough bytes remain for the value field before parsing.
+      // Without this, fixed-width primitives in @athombv/data-types silently
+      // return 0 on short input - which for IAS Zone `zoneStatus` (map16)
+      // produces an all-bits-false bitmap that looks like "all alarms clear",
+      // and for any status-bearing attribute promotes a truncated value into
+      // a SUCCESS-looking enum.
+      if (DataType.length > 0 && buf.length - i < DataType.length) {
+        throw new ZCLError('MALFORMED_COMMAND');
       }
 
       const entry = DataType.fromBuffer(buf, i, true);

--- a/test/testMalformedFrames.js
+++ b/test/testMalformedFrames.js
@@ -1,0 +1,163 @@
+'use strict';
+
+const assert = require('assert');
+const Node = require('../lib/Node');
+const BoundCluster = require('../lib/BoundCluster');
+const IASZoneCluster = require('../lib/clusters/iasZone');
+const { ZCLStandardHeader } = require('../lib/zclFrames');
+const { ZCLDataTypes } = require('../lib/zclTypes');
+
+/**
+ * Helper: build a mock Node that captures every frame sent back via sendFrame.
+ * Unlike `createMockNode({loopback:true})`, this lets the test inspect the
+ * default-response frames that handleFrame produces (e.g. MALFORMED_COMMAND).
+ */
+function createCapturingNode(endpointId, inputClusterId) {
+  const sentFrames = [];
+  const mockNode = {
+    sendFrame: async (epId, clId, data) => {
+      sentFrames.push({
+        endpointId: epId, clusterId: clId, raw: data,
+      });
+    },
+    endpointDescriptors: [{
+      endpointId,
+      inputClusters: [inputClusterId],
+      outputClusters: [],
+    }],
+  };
+  const node = new Node(mockNode);
+  return { node, sentFrames };
+}
+
+/** Parse a captured ZCL default-response frame back to {cmdId, status}. */
+function parseDefaultResponse(rawFrame) {
+  const frame = ZCLStandardHeader.fromBuffer(rawFrame);
+  // ZCL default response cmdId is 0x0B
+  if (frame.cmdId !== 0x0B) return null;
+  return {
+    forCmdId: frame.data.readUInt8(0),
+    status: ZCLDataTypes.enum8Status.fromBuffer(frame.data, 1),
+  };
+}
+
+describe('Malformed frame hardening', function() {
+  describe('Cluster.handleFrame (server-to-client direction)', function() {
+    it('should not invoke handler on truncated zoneStatusChangeNotification', function(done) {
+      const { node } = createCapturingNode(1, IASZoneCluster.ID);
+
+      node.endpoints[1].clusters.iasZone.onZoneStatusChangeNotification = data => {
+        done(new Error(`handler invoked on malformed frame: ${JSON.stringify(data)}`));
+      };
+
+      const frame = new ZCLStandardHeader();
+      frame.cmdId = IASZoneCluster.COMMANDS.zoneStatusChangeNotification.id;
+      frame.frameControl.directionToClient = true;
+      frame.frameControl.clusterSpecific = true;
+      // Empty payload: the fixed-size args (6 bytes) cannot be parsed.
+      // Pre-fix behavior: silently parses as zoneStatus.alarm1=false, extendedStatus=0,
+      // zoneId=0, delay=0 - a fail-open read for alarm-routing drivers.
+      frame.data = Buffer.alloc(0);
+
+      node.handleFrame(1, IASZoneCluster.ID, frame.toBuffer(), {})
+        .then(() => done())
+        .catch(done);
+    });
+
+    it('should respond with MALFORMED_COMMAND on truncated zoneStatusChangeNotification', async function() {
+      const { node, sentFrames } = createCapturingNode(1, IASZoneCluster.ID);
+
+      const frame = new ZCLStandardHeader();
+      frame.cmdId = IASZoneCluster.COMMANDS.zoneStatusChangeNotification.id;
+      frame.frameControl.directionToClient = true;
+      frame.frameControl.clusterSpecific = true;
+      frame.data = Buffer.from([0x10, 0x00]); // 2 bytes, needs 6
+
+      await node.handleFrame(1, IASZoneCluster.ID, frame.toBuffer(), {});
+
+      // Find the default-response frame the receiver sent back.
+      const response = sentFrames
+        .map(f => parseDefaultResponse(f.raw))
+        .find(r => r && r.forCmdId === IASZoneCluster.COMMANDS.zoneStatusChangeNotification.id);
+
+      assert.ok(response, 'expected a default-response frame to be sent back');
+      assert.strictEqual(response.status, 'MALFORMED_COMMAND',
+        `expected MALFORMED_COMMAND, got ${response.status}`);
+    });
+
+    it('should still invoke handler on well-formed zoneStatusChangeNotification (regression)', function(done) {
+      const { node } = createCapturingNode(1, IASZoneCluster.ID);
+
+      node.endpoints[1].clusters.iasZone.onZoneStatusChangeNotification = data => {
+        try {
+          assert.strictEqual(data.zoneStatus.alarm1, true);
+          assert.strictEqual(data.extendedStatus, 0);
+          assert.strictEqual(data.zoneId, 10);
+          assert.strictEqual(data.delay, 108);
+          done();
+        } catch (err) {
+          done(err);
+        }
+      };
+
+      const frame = new ZCLStandardHeader();
+      frame.cmdId = IASZoneCluster.COMMANDS.zoneStatusChangeNotification.id;
+      frame.frameControl.directionToClient = true;
+      frame.frameControl.clusterSpecific = true;
+      // alarm1 bit set in zoneStatus (map16=0x0001), extendedStatus=0, zoneId=10, delay=108
+      frame.data = Buffer.from([0x01, 0x00, 0x00, 0x0A, 0x6C, 0x00]);
+
+      node.handleFrame(1, IASZoneCluster.ID, frame.toBuffer(), {}).catch(done);
+    });
+  });
+
+  describe('BoundCluster.handleFrame (client-to-server direction)', function() {
+    it('should not invoke handler on truncated zoneEnrollResponse', async function() {
+      const { node } = createCapturingNode(1, IASZoneCluster.ID);
+
+      let handlerCalled = false;
+      node.endpoints[1].bind('iasZone', new (class extends BoundCluster {
+
+        async zoneEnrollResponse(data) {
+          handlerCalled = true;
+          throw new Error(`handler invoked on malformed frame: ${JSON.stringify(data)}`);
+        }
+
+      })());
+
+      const frame = new ZCLStandardHeader();
+      frame.cmdId = IASZoneCluster.COMMANDS.zoneEnrollResponse.id;
+      frame.frameControl.directionToClient = false;
+      frame.frameControl.clusterSpecific = true;
+      // Empty payload: enrollResponseCode (1 byte) and zoneId (1 byte) cannot be parsed.
+      // Pre-fix behavior: silently parses as enrollResponseCode='success', zoneId=0.
+      frame.data = Buffer.alloc(0);
+
+      await node.handleFrame(1, IASZoneCluster.ID, frame.toBuffer(), {});
+
+      assert.strictEqual(handlerCalled, false, 'handler must not be called on truncated frame');
+    });
+
+    it('should respond with MALFORMED_COMMAND on truncated zoneEnrollResponse', async function() {
+      const { node, sentFrames } = createCapturingNode(1, IASZoneCluster.ID);
+
+      node.endpoints[1].bind('iasZone', new BoundCluster());
+
+      const frame = new ZCLStandardHeader();
+      frame.cmdId = IASZoneCluster.COMMANDS.zoneEnrollResponse.id;
+      frame.frameControl.directionToClient = false;
+      frame.frameControl.clusterSpecific = true;
+      frame.data = Buffer.from([0x00]); // 1 byte, needs 2
+
+      await node.handleFrame(1, IASZoneCluster.ID, frame.toBuffer(), {});
+
+      const response = sentFrames
+        .map(f => parseDefaultResponse(f.raw))
+        .find(r => r && r.forCmdId === IASZoneCluster.COMMANDS.zoneEnrollResponse.id);
+
+      assert.ok(response, 'expected a default-response frame to be sent back');
+      assert.strictEqual(response.status, 'MALFORMED_COMMAND',
+        `expected MALFORMED_COMMAND, got ${response.status}`);
+    });
+  });
+});

--- a/test/testMalformedFrames.js
+++ b/test/testMalformedFrames.js
@@ -1,11 +1,16 @@
+// eslint-disable-next-line max-classes-per-file,lines-around-directive
 'use strict';
 
 const assert = require('assert');
 const Node = require('../lib/Node');
 const BoundCluster = require('../lib/BoundCluster');
 const IASZoneCluster = require('../lib/clusters/iasZone');
+const OTACluster = require('../lib/clusters/ota');
 const { ZCLStandardHeader } = require('../lib/zclFrames');
 const { ZCLDataTypes } = require('../lib/zclTypes');
+
+// ZCL data-type id for map16 (declared in @athombv/data-types).
+const ZCL_TYPE_ID_MAP16 = 25;
 
 /**
  * Helper: build a mock Node that captures every frame sent back via sendFrame.
@@ -158,6 +163,131 @@ describe('Malformed frame hardening', function() {
       assert.ok(response, 'expected a default-response frame to be sent back');
       assert.strictEqual(response.status, 'MALFORMED_COMMAND',
         `expected MALFORMED_COMMAND, got ${response.status}`);
+    });
+  });
+
+  describe('Attribute report (reportAttributes / cmdId 0x0A)', function() {
+    /**
+     * Build a reportAttributes frame carrying one attribute record.
+     * @param {number} attrId
+     * @param {number} typeId
+     * @param {Buffer} value - the raw value bytes (may be truncated for tests).
+     */
+    function buildReportAttributesFrame(attrId, typeId, value) {
+      const frame = new ZCLStandardHeader();
+      frame.cmdId = 0x0A;
+      frame.frameControl.directionToClient = true;
+      frame.frameControl.clusterSpecific = false; // global command
+      const header = Buffer.alloc(3);
+      header.writeUInt16LE(attrId, 0);
+      header.writeUInt8(typeId, 2);
+      frame.data = Buffer.concat([header, value]);
+      return frame;
+    }
+
+    it('should not emit attr.zoneStatus on truncated map16 value', async function() {
+      const { node } = createCapturingNode(1, IASZoneCluster.ID);
+
+      let emitted = false;
+      node.endpoints[1].clusters.iasZone.on('attr.zoneStatus', () => {
+        emitted = true;
+      });
+
+      // Attribute id=0x0002 (zoneStatus), type=map16, value bytes missing entirely.
+      const frame = buildReportAttributesFrame(0x0002, ZCL_TYPE_ID_MAP16, Buffer.alloc(0));
+      await node.handleFrame(1, IASZoneCluster.ID, frame.toBuffer(), {});
+
+      assert.strictEqual(emitted, false,
+        'attr.zoneStatus must not fire when the map16 value bytes are missing');
+    });
+
+    it('should respond with MALFORMED_COMMAND on truncated attribute value', async function() {
+      const { node, sentFrames } = createCapturingNode(1, IASZoneCluster.ID);
+
+      // 1 byte of map16 instead of 2.
+      const frame = buildReportAttributesFrame(0x0002, ZCL_TYPE_ID_MAP16, Buffer.from([0x01]));
+      await node.handleFrame(1, IASZoneCluster.ID, frame.toBuffer(), {});
+
+      const response = sentFrames
+        .map(f => parseDefaultResponse(f.raw))
+        .find(r => r && r.forCmdId === 0x0A);
+
+      assert.ok(response, 'expected a default-response frame to be sent back');
+      assert.strictEqual(response.status, 'MALFORMED_COMMAND',
+        `expected MALFORMED_COMMAND, got ${response.status}`);
+    });
+
+    it('should still emit attr.zoneStatus on well-formed report (regression)', async function() {
+      const { node } = createCapturingNode(1, IASZoneCluster.ID);
+
+      let received = null;
+      node.endpoints[1].clusters.iasZone.on('attr.zoneStatus', val => {
+        received = val;
+      });
+
+      // Full report: attrId=0x0002, typeId=map16, value=[0x01, 0x00] (alarm1 bit set).
+      const value = Buffer.from([0x01, 0x00]);
+      const frame = buildReportAttributesFrame(0x0002, ZCL_TYPE_ID_MAP16, value);
+      await node.handleFrame(1, IASZoneCluster.ID, frame.toBuffer(), {});
+
+      assert.ok(received, 'attr.zoneStatus should have fired');
+      assert.strictEqual(received.alarm1, true);
+    });
+  });
+
+  describe('encodeMissingFieldsBehavior: "skip" - empty payload', function() {
+    it('should reject empty queryNextImageRequest', async function() {
+      const { node, sentFrames } = createCapturingNode(1, OTACluster.ID);
+      node.endpoints[1].bind('ota', new BoundCluster());
+
+      const frame = new ZCLStandardHeader();
+      frame.cmdId = OTACluster.COMMANDS.queryNextImageRequest.id;
+      frame.frameControl.directionToClient = false;
+      frame.frameControl.clusterSpecific = true;
+      frame.data = Buffer.alloc(0); // Pre-fix: parses with all zero-filled fields.
+
+      await node.handleFrame(1, OTACluster.ID, frame.toBuffer(), {});
+
+      const response = sentFrames
+        .map(f => parseDefaultResponse(f.raw))
+        .find(r => r && r.forCmdId === OTACluster.COMMANDS.queryNextImageRequest.id);
+
+      assert.ok(response, 'expected a default-response frame');
+      assert.strictEqual(response.status, 'MALFORMED_COMMAND',
+        `expected MALFORMED_COMMAND, got ${response.status}`);
+    });
+
+    it('should still accept queryNextImageRequest without trailing hardwareVersion (regression)', async function() {
+      const { node } = createCapturingNode(1, OTACluster.ID);
+
+      let receivedArgs = null;
+      node.endpoints[1].bind('ota', new (class extends BoundCluster {
+
+        async queryNextImageRequest(args) {
+          receivedArgs = args;
+          return { status: 'NO_IMAGE_AVAILABLE' };
+        }
+
+      })());
+
+      const frame = new ZCLStandardHeader();
+      frame.cmdId = OTACluster.COMMANDS.queryNextImageRequest.id;
+      frame.frameControl.directionToClient = false;
+      frame.frameControl.clusterSpecific = true;
+      // 9 bytes: fieldControl(1) + manufacturerCode(2) + imageType(2) + fileVersion(4).
+      // Trailing hardwareVersion(2) omitted because fieldControl bit 0 is not set.
+      frame.data = Buffer.from([
+        0x00, // fieldControl
+        0x34, 0x12, // manufacturerCode = 0x1234
+        0x21, 0x43, // imageType = 0x4321
+        0x01, 0x00, 0x00, 0x00, // fileVersion = 1
+      ]);
+
+      await node.handleFrame(1, OTACluster.ID, frame.toBuffer(), {});
+
+      assert.ok(receivedArgs, 'handler should have been called');
+      assert.strictEqual(receivedArgs.manufacturerCode, 0x1234);
+      assert.strictEqual(receivedArgs.imageType, 0x4321);
     });
   });
 });


### PR DESCRIPTION
## Summary

Hardens command-argument and attribute-record parsing against truncated wire input. Without these checks, `@athombv/data-types` silently zero-fills missing bytes, producing a plausible-looking parse result that:

- For IAS Zone `zoneStatusChangeNotification` and attribute reports of `zoneStatus`: reads as `zoneStatus.alarm1 === false` (i.e. "all clear" while truncated frames look indistinguishable from a real "no alarm" report at the consumer layer).
- For any status-bearing response: reads as `status === 'SUCCESS'` (because the zero value is what every ZCL status enum maps to `SUCCESS`).

This is a robustness / defense-in-depth change. The framing is correctness-first: safety-critical cluster handlers should never observe args from a payload too short to populate them, and "downstream code cannot tell whether the device reported a valid `false` value or whether the parser invented it from missing bytes" is a trust-boundary problem worth closing.

## Changes

### 1. Command arg parsing - length precheck + try/catch

`Cluster.handleFrame` ([Cluster.js:780](lib/Cluster.js)) and `BoundCluster.handleFrame` ([BoundCluster.js:312](lib/BoundCluster.js)) now route command-arg parsing through a new helper, `lib/util/parseCommandArgs.js`:

- Payload shorter than `Math.abs(command.args.length)` is rejected before the parser runs.
- Payload that throws mid-parse (e.g. an `octstr` length prefix overruns the remaining buffer) is caught and converted to `MALFORMED_COMMAND` instead of leaking a `RangeError` as a generic `FAILURE`.
- `Endpoint.handleFrame` already converts thrown `ZCLError`s into proper ZCL default-response frames back to the sender, so no surrounding wiring changes are needed.

### 2. Attribute report (`reportAttributes`) value-length validation

`ZCLAttributeDataRecord.fromBuf` in [`zclFrames.js`](lib/zclFrames.js) now validates that enough bytes remain for the value field before calling `DataType.fromBuffer`. Without this check, a `reportAttributes` frame carrying a valid attribute header but a truncated value bypassed the command-arg precheck entirely (because `reportAttributes` declares args as a raw buffer) and re-introduced the same silent zero-fill at the inner record layer. Concretely, a `zoneStatus` (map16) attribute report missing its value bytes parsed as an all-bits-false bitmap, emitted `attr.zoneStatus`, and reached IAS-Zone drivers as "all alarms clear".

On insufficient bytes, throws `ZCLError('MALFORMED_COMMAND')`. Variable-length value fields are not covered by this check (see "Out of scope" below).

### 3. Tighter `encodeMissingFieldsBehavior: 'skip'` exemption

The initial precheck fully exempted `'skip'` commands (OTA) because they allow trailing fields to be omitted. That was broader than needed: every `'skip'` command in the codebase has a mandatory leading discriminator (status / fieldControl / payloadType) whose presence determines which subsequent fields are valid. Without that byte, the parse is meaningless.

The exemption now requires at least the first field's byte width. This preserves the legitimate "omit trailing optional fields" path (e.g. `queryNextImageRequest` without `hardwareVersion`) while rejecting empty / sub-leading-byte payloads.

## Test plan

All new tests written TDD-style (red first, then implementation).

- [x] **Command path** - truncated `zoneStatusChangeNotification`, truncated `zoneEnrollResponse`:
  - Handlers not invoked.
  - Sender receives `MALFORMED_COMMAND` default-response.
  - Well-formed equivalents still invoke the handler with the expected args (regression).
- [x] **Attribute report path** - truncated `zoneStatus` (map16) value:
  - `attr.zoneStatus` event does not fire.
  - Sender receives `MALFORMED_COMMAND` default-response.
  - Well-formed `zoneStatus` report still fires `attr.zoneStatus` with `alarm1 === true` (regression).
- [x] **`'skip'` exemption** - empty `queryNextImageRequest`:
  - Rejected with `MALFORMED_COMMAND`.
  - 9-byte `queryNextImageRequest` without trailing `hardwareVersion` still parses successfully and reaches the handler with the expected `manufacturerCode` / `imageType` (regression - preserves existing OTA tolerance).
- [x] Full suite: 86/86 passing (76 pre-existing + 10 new). No regressions.
- [x] Lint clean.

## Out of scope

This PR is consumer-side hardening. The deeper fix sits in `@athombv/data-types` and includes:

- Fixed-width reads (`uintFromBuf`, `enumFromBuf`, `dataFromBuf`) failing on insufficient bytes instead of returning `0` / a truncated buffer.
- Variable-length reads (`bufferFromBuf`) failing instead of returning a truncated buffer with `isPartial = true` (an undocumented flag no consumer checks - the source even contains a `// TODO: FIXME` next to it).
- Bitmap slices not aliasing the source buffer (TOCTOU hazard if a radio driver reuses receive buffers).
- `Struct` constructor rejecting prototype-chain keys like `constructor` as field names.

Two of those (Bitmap defensive copy, Struct prototype-chain guard) are already in flight upstream at athombv/node-data-types#44. The `*FromBuf` truncation behavior is the breaking change that needs a separate discussion (either a `strict` opt-in flag or a major-version flip).

As a consequence, this PR does not close:

- Variable-length attribute / command field overrun via `bufferFromBuf`'s `isPartial` path. The `try/catch` in `parseCommandArgs` catches nothing here because nothing throws.
- Attribute reports carrying a variable-length value field (e.g. `octstr`-typed attributes) where the length prefix overruns the remaining buffer.

These can be closed either upstream (cleanest) or by recursing parsed args downstream to reject any Buffer with `isPartial === true` (less clean, but unblocks without coordination). Tracked separately.