### PR TITLE
Small type fixes

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2911,7 +2911,7 @@ declare module "zigbee-clusters" {
     [handlerKey: `on${Capitalize<string>}`]: ((...args: any[]) => unknown) | undefined;
 
     readAttributes<K extends keyof (Attributes & types.GLOBAL_ATTRIBUTES) | number>(attributes: ReadonlyArray<K>, opts?: {timeout?: number}): Promise<{[attribute in K]: types.AttributesFromDefinition<Attributes & types.GLOBAL_ATTRIBUTES>[attribute]}>;
-    writeAttributes<K extends keyof (Attributes & types.GLOBAL_ATTRIBUTES)>(attributes: {[attribute in K]: types.AttributesFromDefinition<Attributes & types.GLOBAL_ATTRIBUTES>[attribute]}, opts?: {timeout?: number}): Promise<{[attribute in K]: {id: number, status: 'SUCCESS' | 'FAILURE'}}>
+    writeAttributes<K extends keyof (Attributes & types.GLOBAL_ATTRIBUTES)>(attributes: {[attribute in K]?: types.AttributesFromDefinition<Attributes & types.GLOBAL_ATTRIBUTES>[attribute]}, opts?: {timeout?: number}): Promise<{[attribute in K]: {id: number, status: 'SUCCESS' | 'FAILURE'}}>
 
     configureReporting(attributes: types.AttributeReportingConfiguration<Extract<keyof (Attributes & types.GLOBAL_ATTRIBUTES), string>>, opts?: {timeout?: number}): Promise<void>;
     readReportingConfiguration(attributes: ReadonlyArray<Extract<keyof (Attributes & types.GLOBAL_ATTRIBUTES), string> | number>, opts?: {timeout?: number}): Promise<Array<types.ReadReportingConfigurationResponse>>;

--- a/index.d.ts
+++ b/index.d.ts
@@ -2680,7 +2680,7 @@ declare module "zigbee-clusters" {
     enum8Status: ZCLDataType<types.ZCLEnum8Status>
   };
 
-  function debug(flag: boolean, namespaces: string): void;
+  function debug(flag?: boolean, namespaces?: string): void;
 
   interface ZigbeeNode {
     /**

--- a/scripts/template.d.ts.txt
+++ b/scripts/template.d.ts.txt
@@ -6,7 +6,7 @@ declare module 'zigbee-clusters' {
     enum8Status: ZCLDataType<types.ZCLEnum8Status>
   };
 
-  function debug(flag: boolean, namespaces: string): void;
+  function debug(flag?: boolean, namespaces?: string): void;
 
   interface ZigbeeNode {
     /**

--- a/scripts/template.d.ts.txt
+++ b/scripts/template.d.ts.txt
@@ -237,7 +237,7 @@ declare module 'zigbee-clusters' {
     [handlerKey: `on${Capitalize<string>}`]: ((...args: any[]) => unknown) | undefined;
 
     readAttributes<K extends keyof (Attributes & types.GLOBAL_ATTRIBUTES) | number>(attributes: ReadonlyArray<K>, opts?: {timeout?: number}): Promise<{[attribute in K]: types.AttributesFromDefinition<Attributes & types.GLOBAL_ATTRIBUTES>[attribute]}>;
-    writeAttributes<K extends keyof (Attributes & types.GLOBAL_ATTRIBUTES)>(attributes: {[attribute in K]: types.AttributesFromDefinition<Attributes & types.GLOBAL_ATTRIBUTES>[attribute]}, opts?: {timeout?: number}): Promise<{[attribute in K]: {id: number, status: 'SUCCESS' | 'FAILURE'}}>
+    writeAttributes<K extends keyof (Attributes & types.GLOBAL_ATTRIBUTES)>(attributes: {[attribute in K]?: types.AttributesFromDefinition<Attributes & types.GLOBAL_ATTRIBUTES>[attribute]}, opts?: {timeout?: number}): Promise<{[attribute in K]: {id: number, status: 'SUCCESS' | 'FAILURE'}}>
 
     configureReporting(attributes: types.AttributeReportingConfiguration<Extract<keyof (Attributes & types.GLOBAL_ATTRIBUTES), string>>, opts?: {timeout?: number}): Promise<void>;
     readReportingConfiguration(attributes: ReadonlyArray<Extract<keyof (Attributes & types.GLOBAL_ATTRIBUTES), string> | number>, opts?: {timeout?: number}): Promise<Array<types.ReadReportingConfigurationResponse>>;


### PR DESCRIPTION
While using the new types I found some small mistakes I missed.

The arguments of debug() are not marked optional in the JSdoc, but they have default values.
The attribute argument requires all attributes be present, but  you can just give part of them.