### PR TITLE
Add missing manufacturerId to CommandDefinition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -3239,6 +3239,7 @@ declare module "zigbee-clusters" {
 
     type CommandDefinition = {
       id: number,
+      manufacturerId?: number,
       direction?: CommandDirection,
       args?: {
         [argName: string]: ZCLDataType<any>,

--- a/scripts/template.d.ts.txt
+++ b/scripts/template.d.ts.txt
@@ -565,6 +565,7 @@ declare module 'zigbee-clusters' {
 
     type CommandDefinition = {
       id: number,
+      manufacturerId?: number,
       direction?: CommandDirection,
       args?: {
         [argName: string]: ZCLDataType<any>,


### PR DESCRIPTION
The `manufacturerId` field is missing from the command definition, this PR adds it.