### PR TITLE
Add missing runningMode attribute definition for thermostat cluster

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1782,6 +1782,7 @@ declare module "zigbee-clusters" {
     controlSequenceOfOperation: { id: 0x1b, type: ZCLDataType<"cooling" | "coolingWithReheat" | "heating" | "heatingWithReheat" | "coolingAndHeating4Pipes" | "coolingAndHeating4PipesWithReheat"> },
     systemMode: { id: 0x1c, type: ZCLDataType<"off" | "auto" | "cool" | "heat" | "emergencyHeating" | "precooling" | "fanOnly" | "dry" | "sleep"> },
     alarmMask: { id: 0x1d, type: ZCLDataType<Bitmap<"initializationFailure" | "hardwareFailure" | "selfCalibrationFailure">> },
+    runningMode: { id: 0x1e, type: ZCLDataType<"off" | "cool" | "heat"> },
   };
   type ThermostatClusterCommands = {
     setSetpoint: { id: 0x00, direction: "DIRECTION_SERVER_TO_CLIENT", args: {

--- a/lib/clusters/thermostat.js
+++ b/lib/clusters/thermostat.js
@@ -50,6 +50,14 @@ const ATTRIBUTES = {
     }),
   },
   alarmMask: { id: 29, type: ZCLDataTypes.map8('initializationFailure', 'hardwareFailure', 'selfCalibrationFailure') },
+  runningMode: {
+    id: 30,
+    type: ZCLDataTypes.enum8({
+      off: 0,
+      cool: 3,
+      heat: 4,
+    }),
+  },
 };
 
 const COMMANDS = {


### PR DESCRIPTION
See 6.3.2.2.2.15 (Thermostat Running Mode Attribute) of the [ZCL spec](https://zigbeealliance.org/wp-content/uploads/2021/10/07-5123-08-Zigbee-Cluster-Library.pdf).