### PR TITLE
Add Thermostat User Interface Configuration Cluster definition

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1816,6 +1816,14 @@ declare module "zigbee-clusters" {
   type DehumidificationControlClusterCommands = Record<never, never>;
   class DehumidificationControlCluster<Attributes extends types.AttributeDefinitions = DehumidificationControlClusterAttributes, Commands extends types.CommandDefinitions = DehumidificationControlClusterCommands> extends Cluster<Attributes, Commands> {
   }
+  type ThermostatUserInterfaceConfigurationClusterAttributes = {
+    temperatureDisplayMode: { id: 0x00, type: ZCLDataType<"celsius" | "fahrenheit"> },
+    keypadLockout: { id: 0x01, type: ZCLDataType<"none" | "level1" | "level2" | "level3" | "level4" | "level5"> },
+    scheduleProgrammingVisibility: { id: 0x02, type: ZCLDataType<"enabled" | "disabled"> },
+  };
+  type ThermostatUserInterfaceConfigurationClusterCommands = Record<never, never>;
+  class ThermostatUserInterfaceConfigurationCluster<Attributes extends types.AttributeDefinitions = ThermostatUserInterfaceConfigurationClusterAttributes, Commands extends types.CommandDefinitions = ThermostatUserInterfaceConfigurationClusterCommands> extends Cluster<Attributes, Commands> {
+  }
   type ColorControlClusterAttributes = {
     currentHue: { id: 0x00, type: ZCLDataType<number> },
     currentSaturation: { id: 0x01, type: ZCLDataType<number> },
@@ -2517,6 +2525,12 @@ declare module "zigbee-clusters" {
       ATTRIBUTES: Readonly<ThermostatClusterAttributes>,
       COMMANDS: Readonly<ThermostatClusterCommands>,
     },
+    THERMOSTAT_UI_CONFIGURATION: {
+      ID: 0x0204,
+      NAME: "thermostatUserInterfaceConfiguration",
+      ATTRIBUTES: Readonly<ThermostatUserInterfaceConfigurationClusterAttributes>,
+      COMMANDS: Readonly<ThermostatUserInterfaceConfigurationClusterCommands>,
+    },
     PUMP_CONFIGURATION_AND_CONTROL: {
       ID: 0x0200,
       NAME: "pumpConfigurationAndControl",
@@ -2654,6 +2668,7 @@ declare module "zigbee-clusters" {
     "doorLock"?: DoorLockCluster;
     "windowCovering"?: WindowCoveringCluster;
     "thermostat"?: ThermostatCluster;
+    "thermostatUserInterfaceConfiguration"?: ThermostatUserInterfaceConfigurationCluster;
     "pumpConfigurationAndControl"?: PumpConfigurationAndControlCluster;
     "fanControl"?: FanControlCluster;
     "colorControl"?: ColorControlCluster;

--- a/lib/clusters/index.js
+++ b/lib/clusters/index.js
@@ -30,6 +30,7 @@ const ThermostatCluster = require('./thermostat');
 const PumpConfigurationAndControlCluster = require('./pumpConfigurationAndControl');
 const FanControlCluster = require('./fanControl');
 const DehumidificationControlCluster = require('./dehumidificationControl');
+const ThermostatUserInterfaceConfigurationCluster = require('./thermostatUserInterfaceConfiguration');
 const ColorControlCluster = require('./colorControl');
 const BallastConfigurationCluster = require('./ballastConfiguration');
 const IlluminanceMeasurementCluster = require('./illuminanceMeasurement');
@@ -95,6 +96,7 @@ module.exports = {
   PumpConfigurationAndControlCluster, // 0x0200 => 512
   FanControlCluster, // 0x0202 => 514
   DehumidificationControlCluster, // 0x0203 => 515
+  ThermostatUserInterfaceConfigurationCluster, // 0x0204 => 516
   ColorControlCluster, // 0x0300 => 768
   BallastConfigurationCluster, // 0x0301 => 769
   IlluminanceMeasurementCluster, // 0x0400 => 1024
@@ -139,6 +141,7 @@ module.exports = {
     DOOR_LOCK: destructConstProps(DoorLockCluster),
     WINDOW_COVERING: destructConstProps(WindowCoveringCluster),
     THERMOSTAT: destructConstProps(ThermostatCluster),
+    THERMOSTAT_UI_CONFIGURATION: destructConstProps(ThermostatUserInterfaceConfigurationCluster),
     PUMP_CONFIGURATION_AND_CONTROL: destructConstProps(PumpConfigurationAndControlCluster),
     FAN_CONTROL: destructConstProps(FanControlCluster),
     COLOR_CONTROL: destructConstProps(ColorControlCluster),

--- a/lib/clusters/thermostatUserInterfaceConfiguration.js
+++ b/lib/clusters/thermostatUserInterfaceConfiguration.js
@@ -1,0 +1,58 @@
+'use strict';
+
+const Cluster = require('../Cluster');
+const { ZCLDataTypes } = require('../zclTypes');
+
+const ATTRIBUTES = {
+  temperatureDisplayMode: {
+    id: 0,
+    type: ZCLDataTypes.enum8({
+      celsius: 0,
+      fahrenheit: 1,
+    }),
+  },
+  keypadLockout: {
+    id: 1,
+    type: ZCLDataTypes.enum8({
+      none: 0,
+      level1: 1,
+      level2: 2,
+      level3: 3,
+      level4: 4,
+      level5: 5,
+    }),
+  },
+  scheduleProgrammingVisibility: {
+    id: 2,
+    type: ZCLDataTypes.enum8({
+      enabled: 0,
+      disabled: 1,
+    }),
+  },
+};
+
+const COMMANDS = {};
+
+class ThermostatUserInterfaceConfigurationCluster extends Cluster {
+
+  static get ID() {
+    return 516;
+  }
+
+  static get NAME() {
+    return 'thermostatUserInterfaceConfiguration';
+  }
+
+  static get ATTRIBUTES() {
+    return ATTRIBUTES;
+  }
+
+  static get COMMANDS() {
+    return COMMANDS;
+  }
+
+}
+
+Cluster.addCluster(ThermostatUserInterfaceConfigurationCluster);
+
+module.exports = ThermostatUserInterfaceConfigurationCluster;


### PR DESCRIPTION
Add a definition for the Thermostat User Interface Configuration cluster as defined in 6.6 in the [ZCL Spec](https://zigbeealliance.org/wp-content/uploads/2021/10/07-5123-08-Zigbee-Cluster-Library.pdf).