### PR TITLE
Add StartUpOnOff and GlobalSceneControl attributes to On/Off cluster

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -226,8 +226,10 @@ declare module "zigbee-clusters" {
   }
   type OnOffClusterAttributes = {
     onOff: { id: 0x00, type: ZCLDataType<boolean> },
+    globalSceneControl: { id: 0x4000, type: ZCLDataType<boolean> },
     onTime: { id: 0x4001, type: ZCLDataType<number> },
     offWaitTime: { id: 0x4002, type: ZCLDataType<number> },
+    startUpOnOff: { id: 0x4003, type: ZCLDataType<"off" | "on" | "toggle" | "previous"> },
   };
   type OnOffClusterCommands = {
     setOff: { id: 0x00, direction: "DIRECTION_SERVER_TO_CLIENT" },

--- a/lib/clusters/onOff.js
+++ b/lib/clusters/onOff.js
@@ -5,8 +5,18 @@ const { ZCLDataTypes } = require('../zclTypes');
 
 const ATTRIBUTES = {
   onOff: { id: 0, type: ZCLDataTypes.bool },
+  globalSceneControl: { id: 16384, type: ZCLDataTypes.bool },
   onTime: { id: 16385, type: ZCLDataTypes.uint16 },
   offWaitTime: { id: 16386, type: ZCLDataTypes.uint16 },
+  startUpOnOff: {
+    id: 16387,
+    type: ZCLDataTypes.enum8({
+      off: 0,
+      on: 1,
+      toggle: 2,
+      previous: 255,
+    }),
+  },
 };
 
 const COMMANDS = {


### PR DESCRIPTION
## What

Adds the two On/Off cluster (0x0006) attributes that were missing per the ZCL spec (r8, section 3.8.2.2):

| ID     | Name                 | Type   |
|--------|----------------------|--------|
| 0x4000 | `globalSceneControl` | bool   |
| 0x4003 | `startUpOnOff`       | enum8  |

`startUpOnOff` enables configuring power-on behavior. Enum values follow ZCL Table 3-46:

- `off` (0x00) - set OnOff to off on power up
- `on` (0x01) - set OnOff to on on power up
- `toggle` (0x02) - toggle previous OnOff value
- `previous` (0xff) - restore previous OnOff value

## Why

`startUpOnOff` (power-on behavior) was not exposed by the library, so it couldn't be read/written. `globalSceneControl` was also missing from the same cluster per spec.

## Notes

- Enum keys use the spec semantics (`off`/`on`/`toggle`/`previous`) rather than friendly aliases.
- `index.d.ts` regenerated via `npm run generate-types`.
- Existing tests pass, lint clean.