### PR TITLE
fix: report UNSUPPORTED_ATTRIBUTE instead of FAILURE for missing attributes

### DIFF
--- a/lib/BoundCluster.js
+++ b/lib/BoundCluster.js
@@ -2,14 +2,8 @@
 
 let { debug } = require('./util');
 const { ZCLDataType } = require('./zclTypes');
-const { getLogId, getPropertyDescriptor } = require('./util');
+const { getLogId, getPropertyDescriptor, ZCLError } = require('./util');
 const Cluster = require('./Cluster');
-
-// Thrown to pick a specific ZCL status from inside the attribute try/catch blocks below. Symbols
-// rather than Errors so they can never be confused with a genuine failure thrown by a getter,
-// setter or data type; their description doubles as the status name (ZCL R8, 2.5.2.2 and 2.5.4.2).
-const UNSUPPORTED_ATTRIBUTE = Symbol('UNSUPPORTED_ATTRIBUTE');
-const READ_ONLY = Symbol('READ_ONLY');
 
 debug = debug.extend('bound-cluster');
 
@@ -63,11 +57,11 @@ class BoundCluster {
         const attr = this.cluster.attributesById[aId];
         try {
           if (!attr) {
-            throw UNSUPPORTED_ATTRIBUTE;
+            throw new ZCLError('UNSUPPORTED_ATTRIBUTE');
           }
           const value = this[attr.name];
           if (typeof value === 'undefined') {
-            throw UNSUPPORTED_ATTRIBUTE;
+            throw new ZCLError('UNSUPPORTED_ATTRIBUTE');
           }
           attr.type.toBuffer(result, value, 0);
           return {
@@ -76,11 +70,15 @@ class BoundCluster {
             value,
           };
         } catch (e) {
-          if (e === UNSUPPORTED_ATTRIBUTE) {
-            debug(this.logId, 'Unsupported attribute:', attr ? attr.name || aId : aId);
+          // A ZCLError names the status to report for this one attribute. Thrown just above for an
+          // attribute that does not exist here, but a getter may throw one too - honour that rather
+          // than flattening it to FAILURE, so an implementation can pick its own per-attribute
+          // status.
+          if (e instanceof ZCLError) {
+            debug(this.logId, 'Attribute rejected:', attr ? attr.name || aId : aId, e.zclStatus);
             return {
               id: aId,
-              status: 'UNSUPPORTED_ATTRIBUTE',
+              status: e.zclStatus,
             };
           }
           debug(this.logId, 'Failed to parse attribute:', attr ? attr.name || aId : aId, e.message);
@@ -115,7 +113,7 @@ class BoundCluster {
         const attr = this.cluster.attributesById[attrValue.id];
         try {
           if (!attr) {
-            throw UNSUPPORTED_ATTRIBUTE;
+            throw new ZCLError('UNSUPPORTED_ATTRIBUTE');
           }
           if (typeof attrValue.value === 'undefined') {
             throw new Error('not_parsable');
@@ -123,10 +121,10 @@ class BoundCluster {
           const descriptor = getPropertyDescriptor(this, attr.name);
           if (!descriptor) {
             // Neither a getter nor a setter: this device does not implement the attribute at all.
-            throw UNSUPPORTED_ATTRIBUTE;
+            throw new ZCLError('UNSUPPORTED_ATTRIBUTE');
           }
           if (!descriptor.set) {
-            throw READ_ONLY;
+            throw new ZCLError('READ_ONLY');
           }
 
           this[attr.name] = attrValue.value;
@@ -136,11 +134,13 @@ class BoundCluster {
             status: 'SUCCESS',
           };
         } catch (e) {
-          if (e === UNSUPPORTED_ATTRIBUTE || e === READ_ONLY) {
-            debug(this.logId, 'Rejected write to attribute:', attr ? attr.name || attrValue.id : attrValue.id, e.description);
+          // As in readAttributes: a ZCLError carries the status for this record, whether it came
+          // from the checks above or from a setter that wants to reject the write on its own terms.
+          if (e instanceof ZCLError) {
+            debug(this.logId, 'Rejected write to attribute:', attr ? attr.name || attrValue.id : attrValue.id, e.zclStatus);
             return {
               id: attrValue.id,
-              status: e.description,
+              status: e.zclStatus,
             };
           }
           debug(this.logId, 'Error: failed to parse attribute:', attr ? attr.name || attrValue.id : attrValue.id, e.message);

--- a/lib/BoundCluster.js
+++ b/lib/BoundCluster.js
@@ -5,6 +5,12 @@ const { ZCLDataType } = require('./zclTypes');
 const { getLogId, getPropertyDescriptor } = require('./util');
 const Cluster = require('./Cluster');
 
+// Thrown to pick a specific ZCL status from inside the attribute try/catch blocks below. Symbols
+// rather than Errors so they can never be confused with a genuine failure thrown by a getter,
+// setter or data type; their description doubles as the status name (ZCL R8, 2.5.2.2 and 2.5.4.2).
+const UNSUPPORTED_ATTRIBUTE = Symbol('UNSUPPORTED_ATTRIBUTE');
+const READ_ONLY = Symbol('READ_ONLY');
+
 debug = debug.extend('bound-cluster');
 
 /**
@@ -56,9 +62,12 @@ class BoundCluster {
       .map(aId => {
         const attr = this.cluster.attributesById[aId];
         try {
+          if (!attr) {
+            throw UNSUPPORTED_ATTRIBUTE;
+          }
           const value = this[attr.name];
           if (typeof value === 'undefined') {
-            throw new Error('not_implemented');
+            throw UNSUPPORTED_ATTRIBUTE;
           }
           attr.type.toBuffer(result, value, 0);
           return {
@@ -67,6 +76,13 @@ class BoundCluster {
             value,
           };
         } catch (e) {
+          if (e === UNSUPPORTED_ATTRIBUTE) {
+            debug(this.logId, 'Unsupported attribute:', attr ? attr.name || aId : aId);
+            return {
+              id: aId,
+              status: 'UNSUPPORTED_ATTRIBUTE',
+            };
+          }
           debug(this.logId, 'Failed to parse attribute:', attr ? attr.name || aId : aId, e.message);
         }
 
@@ -98,11 +114,19 @@ class BoundCluster {
       .map(attrValue => {
         const attr = this.cluster.attributesById[attrValue.id];
         try {
+          if (!attr) {
+            throw UNSUPPORTED_ATTRIBUTE;
+          }
           if (typeof attrValue.value === 'undefined') {
             throw new Error('not_parsable');
           }
-          if (!(getPropertyDescriptor(this, attr.name) || {}).set) {
-            throw new Error('not_settable');
+          const descriptor = getPropertyDescriptor(this, attr.name);
+          if (!descriptor) {
+            // Neither a getter nor a setter: this device does not implement the attribute at all.
+            throw UNSUPPORTED_ATTRIBUTE;
+          }
+          if (!descriptor.set) {
+            throw READ_ONLY;
           }
 
           this[attr.name] = attrValue.value;
@@ -112,6 +136,13 @@ class BoundCluster {
             status: 'SUCCESS',
           };
         } catch (e) {
+          if (e === UNSUPPORTED_ATTRIBUTE || e === READ_ONLY) {
+            debug(this.logId, 'Rejected write to attribute:', attr ? attr.name || attrValue.id : attrValue.id, e.description);
+            return {
+              id: attrValue.id,
+              status: e.description,
+            };
+          }
           debug(this.logId, 'Error: failed to parse attribute:', attr ? attr.name || attrValue.id : attrValue.id, e.message);
         }
 

--- a/test/boundClusterAttributeStatus.js
+++ b/test/boundClusterAttributeStatus.js
@@ -5,6 +5,7 @@ const assert = require('assert');
 
 const BoundCluster = require('../lib/BoundCluster');
 const BasicCluster = require('../lib/clusters/basic');
+const { ZCLError } = require('../lib/util');
 
 // Attribute ids on the basic cluster.
 const MODEL_ID = 0x0005;
@@ -86,6 +87,21 @@ describe('BoundCluster attribute status codes', function() {
       assert.equal(records[0].status, 'UNSUPPORTED_ATTRIBUTE');
     });
 
+    it('honours a ZCLError thrown by a getter instead of flattening it to FAILURE', async function() {
+      const bound = bind(new class extends BoundCluster {
+
+        get modelId() {
+          throw new ZCLError('NOT_AUTHORIZED');
+        }
+
+      }());
+      const records = readStatuses(await bound.readAttributes({ attributes: [MODEL_ID] }));
+
+      // The per-attribute status is data on the error, so an implementation can pick its own rather
+      // than being limited to the two this class throws itself.
+      assert.equal(records[0].status, 'NOT_AUTHORIZED');
+    });
+
     it('still reports SUCCESS with a value for an implemented attribute', async function() {
       const bound = bind(new class extends BoundCluster {
 
@@ -149,6 +165,25 @@ describe('BoundCluster attribute status codes', function() {
 
       // ZCL R8 2.5.4.2 check 3: a read-only attribute SHALL be READ_ONLY, not FAILURE.
       assert.equal(attributes[0].status, 'READ_ONLY');
+    });
+
+    it('honours a ZCLError thrown by a setter', async function() {
+      const bound = bind(new class extends BoundCluster {
+
+        get modelId() {
+          return this._modelId;
+        }
+
+        set modelId(value) {
+          throw new ZCLError('INVALID_VALUE');
+        }
+
+      }());
+      const { attributes } = await bound.writeAttributes({
+        attributes: writeBuffer([{ id: MODEL_ID, value: 'Other' }]),
+      });
+
+      assert.equal(attributes[0].status, 'INVALID_VALUE');
     });
 
     it('still reports SUCCESS for a writable attribute', async function() {

--- a/test/boundClusterAttributeStatus.js
+++ b/test/boundClusterAttributeStatus.js
@@ -1,0 +1,157 @@
+// eslint-disable-next-line max-classes-per-file,lines-around-directive
+'use strict';
+
+const assert = require('assert');
+
+const BoundCluster = require('../lib/BoundCluster');
+const BasicCluster = require('../lib/clusters/basic');
+
+// Attribute ids on the basic cluster.
+const MODEL_ID = 0x0005;
+const UNREGISTERED_ID = 0x1234;
+
+/** Bind a BoundCluster to the basic cluster the way Endpoint.bind does, without a node. */
+function bind(boundCluster) {
+  boundCluster.cluster = BasicCluster;
+  return boundCluster;
+}
+
+/** Decode the read-attributes response buffer back into status records. */
+function readStatuses(response) {
+  return BasicCluster.attributeArrayStatusDataType.fromBuffer(response.attributes, 0);
+}
+
+describe('BoundCluster attribute status codes', function() {
+  describe('readAttributes', function() {
+    it('reports UNSUPPORTED_ATTRIBUTE for an id the cluster does not define', async function() {
+      const bound = bind(new class extends BoundCluster {}());
+      const records = readStatuses(await bound.readAttributes({ attributes: [UNREGISTERED_ID] }));
+
+      assert.equal(records.length, 1);
+      assert.equal(records[0].id, UNREGISTERED_ID);
+      // ZCL R8 2.5.2.2: an attribute that does not exist SHALL be UNSUPPORTED_ATTRIBUTE,
+      // not FAILURE.
+      assert.equal(records[0].status, 'UNSUPPORTED_ATTRIBUTE');
+    });
+
+    it('reports UNSUPPORTED_ATTRIBUTE for a defined but unimplemented attribute', async function() {
+      const bound = bind(new class extends BoundCluster {}());
+      const records = readStatuses(await bound.readAttributes({ attributes: [MODEL_ID] }));
+
+      assert.equal(records[0].status, 'UNSUPPORTED_ATTRIBUTE');
+    });
+
+    it('still reports FAILURE when a getter throws', async function() {
+      const bound = bind(new class extends BoundCluster {
+
+        get modelId() {
+          throw new Error('sensor offline');
+        }
+
+      }());
+      const records = readStatuses(await bound.readAttributes({ attributes: [MODEL_ID] }));
+
+      // The attribute exists, so this is a genuine failure and must not be masked as unsupported.
+      assert.equal(records[0].status, 'FAILURE');
+    });
+
+    it('reports FAILURE when the value cannot be serialized', async function() {
+      const bound = bind(new class extends BoundCluster {
+
+        get modelId() {
+          // A string too long for the one-octet length prefix of a ZCL character string.
+          return 'x'.repeat(300);
+        }
+
+      }());
+      const records = readStatuses(await bound.readAttributes({ attributes: [MODEL_ID] }));
+
+      assert.equal(records[0].status, 'FAILURE');
+    });
+
+    it('still reports SUCCESS with a value for an implemented attribute', async function() {
+      const bound = bind(new class extends BoundCluster {
+
+        get modelId() {
+          return 'Homey';
+        }
+
+      }());
+      const records = readStatuses(await bound.readAttributes({ attributes: [MODEL_ID] }));
+
+      assert.equal(records[0].status, 'SUCCESS');
+      assert.equal(records[0].value, 'Homey');
+    });
+
+    it('reports a per-attribute status, not one status for the whole request', async function() {
+      const bound = bind(new class extends BoundCluster {
+
+        get modelId() {
+          return 'Homey';
+        }
+
+      }());
+      const records = readStatuses(
+        await bound.readAttributes({ attributes: [MODEL_ID, UNREGISTERED_ID] }),
+      );
+
+      assert.equal(records.length, 2);
+      assert.equal(records[0].status, 'SUCCESS');
+      assert.equal(records[1].status, 'UNSUPPORTED_ATTRIBUTE');
+    });
+  });
+
+  describe('writeAttributes', function() {
+    /** Build the wire payload writeAttributes expects. */
+    function writeBuffer(records) {
+      const buf = Buffer.alloc(255);
+      const len = BasicCluster.attributeArrayDataType.toBuffer(buf, records, 0);
+      return buf.slice(0, len);
+    }
+
+    it('reports UNSUPPORTED_ATTRIBUTE for an attribute this device does not implement', async function() {
+      const bound = bind(new class extends BoundCluster {}());
+      const { attributes } = await bound.writeAttributes({
+        attributes: writeBuffer([{ id: MODEL_ID, value: 'Homey' }]),
+      });
+
+      assert.equal(attributes[0].status, 'UNSUPPORTED_ATTRIBUTE');
+    });
+
+    it('reports READ_ONLY for an attribute exposed with a getter but no setter', async function() {
+      const bound = bind(new class extends BoundCluster {
+
+        get modelId() {
+          return 'Homey';
+        }
+
+      }());
+      const { attributes } = await bound.writeAttributes({
+        attributes: writeBuffer([{ id: MODEL_ID, value: 'Other' }]),
+      });
+
+      // ZCL R8 2.5.4.2 check 3: a read-only attribute SHALL be READ_ONLY, not FAILURE.
+      assert.equal(attributes[0].status, 'READ_ONLY');
+    });
+
+    it('still reports SUCCESS for a writable attribute', async function() {
+      const bound = bind(new class extends BoundCluster {
+
+        get modelId() {
+          return this._modelId;
+        }
+
+        set modelId(value) {
+          this._modelId = value;
+        }
+
+      }());
+      const { attributes } = await bound.writeAttributes({
+        attributes: writeBuffer([{ id: MODEL_ID, value: 'Other' }]),
+      });
+
+      assert.equal(attributes[0].status, 'SUCCESS');
+      assert.equal(bound.modelId, 'Other');
+    });
+  });
+});

--- a/test/boundClusterAttributeStatus.js
+++ b/test/boundClusterAttributeStatus.js
@@ -69,6 +69,23 @@ describe('BoundCluster attribute status codes', function() {
       assert.equal(records[0].status, 'FAILURE');
     });
 
+    it('reports UNSUPPORTED_ATTRIBUTE for a write-only attribute, not 0x8f', async function() {
+      const bound = bind(new class extends BoundCluster {
+
+        set modelId(value) {
+          this._modelId = value;
+        }
+
+      }());
+      const records = readStatuses(await bound.readAttributes({ attributes: [MODEL_ID] }));
+
+      // ZCL R8 deprecates WRITE_ONLY and reassigns 0x8f to NOT_AUTHORIZED ("a request has been
+      // made to read an attribute that the requestor is not authorized to read"), which is about
+      // permission, not about the attribute being unreadable. R8 defines no read status for a
+      // write-only attribute, so UNSUPPORTED_ATTRIBUTE stays the honest answer: not readable here.
+      assert.equal(records[0].status, 'UNSUPPORTED_ATTRIBUTE');
+    });
+
     it('still reports SUCCESS with a value for an implemented attribute', async function() {
       const bound = bind(new class extends BoundCluster {
 


### PR DESCRIPTION
`BoundCluster.readAttributes` and `writeAttributes` funnelled every failure through a single catch that returned `FAILURE` (0x01). The most common case by far - a remote node asking for an attribute this `BoundCluster` does not implement - is not a failure, and the ZCL spec names the status for it.

`docs/zigbee-cluster-specification-r8.pdf` §2.5.2.2:

> If the attribute identifier does not correspond to an attribute that exists on this device, the device SHALL set the status field of the corresponding read attribute status record to UNSUPPORTED_ATTRIBUTE and SHALL not include an attribute value field.

§2.5.4.2 gives writes an ordered checklist, of which two apply here: an unsupported attribute is `UNSUPPORTED_ATTRIBUTE` (check 1), and one designated read only is `READ_ONLY` (check 3). Neither is `FAILURE`.

## What changes

| Situation | Before | After |
| --- | --- | --- |
| attribute id not defined by the cluster | `FAILURE` | `UNSUPPORTED_ATTRIBUTE` (0x86) |
| defined, but no accessor on this device | `FAILURE` | `UNSUPPORTED_ATTRIBUTE` (0x86) |
| write to a getter with no setter | `FAILURE` | `READ_ONLY` (0x88) |
| getter threw, or value would not serialize | `FAILURE` | `FAILURE` (unchanged) |

Both status codes were already in the `zclTypes` enum; nothing new is defined.

## How the status is selected

Reading `this[attr.name]` can invoke a getter that throws, and that has to stay a genuine `FAILURE` rather than escaping the `.map()` and failing the whole response. So the checks stay inside the existing `try`, and throw a `ZCLError` carrying the status to report.

`ZCLError` already exists in this package and already carries a `zclStatus` - `Endpoint` reads it to choose a Default Response status. That machinery does not cover this case, because it fires at command level whereas these statuses belong in per-attribute records of a response that otherwise succeeds. So the error never escapes the per-attribute block. But it is still the right type: the status travels as data rather than as a sentinel's description, and it is a type a reader of this package already knows.

**This also gives implementations control.** A getter or setter that throws its own `ZCLError` now has that status honoured instead of flattened to `FAILURE`:

```js
get modelId() {
  throw new ZCLError('NOT_AUTHORIZED');
}
```

An earlier revision of this PR used thrown `Symbol`s here, on the reasoning that they "can never be confused with a genuine failure thrown by a getter". That was backwards - honouring a getter's own `ZCLError` is a feature, not a confusion to guard against, and the Symbol version could not do it by construction.

`INVALID_DATA_TYPE` (check 2) is deliberately left alone: the existing `not_parsable` branch cannot distinguish a type mismatch from an undecodable value, and guessing would be worse than the status quo.

## Tests

New `test/boundClusterAttributeStatus.js`, 12 cases, driving `BoundCluster` directly and decoding the response buffer back into status records - the client-side `Cluster.readAttributes` returns a name→value map and discards the status, so a round-trip test cannot see this. Covers both new statuses, both `FAILURE` paths, `SUCCESS`, a mixed request proving the status is per-attribute, the write-only read case, and a getter and setter each throwing their own `ZCLError`.

Three mutants fail the suite: the `instanceof ZCLError` branch disabled, `READ_ONLY` swapped for `FAILURE`, and the status ignored in favour of a hardcoded `FAILURE`.

91 tests pass; `eslint .` is clean.