### PR TITLE
feat: export Endpoint, so a device serving bound clusters need not fake a peer

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -2778,21 +2778,12 @@ declare module "zigbee-clusters" {
     getLogId(endpointId: number, clusterId: number): string;
   }
 
-  /**
-   * Minimum shape an Endpoint needs from its owner. Endpoint only ever calls `sendFrame`, so a
-   * plain object is enough - a device serving bound clusters does not need a full ZCLNode, which
-   * models one remote peer and bakes that peer's address into its own `sendFrame`.
-   */
-  type EndpointInput = {
-    sendFrame(endpointId: number, clusterId: number, frame: Buffer): Promise<unknown>;
-  };
-
-  class Endpoint extends EventEmitter {
-    constructor(node: EndpointInput, descriptor: {
+  class ZCLNodeEndpoint extends EventEmitter {
+    constructor(node: ZCLNode, descriptor: {
       endpointId: number;
       inputClusters: number[];
-      outputClusters?: number[];
-    });
+      outputClusters: number[];
+    }[]);
     // Typed lookup: known cluster names (per the generated `ClustersByName`)
     // resolve to their specific class (e.g. `clusters.onOff` is `OnOffCluster`),
     // while unknown keys fall back to the generic Cluster via the index half.
@@ -2804,19 +2795,7 @@ declare module "zigbee-clusters" {
     unbind(clusterName: string): void;
 
     makeDefaultResponseFrame(receivedFrame: unknown, success: boolean, status: types.ZCLEnum8Status): typeof zclFrames.ZCLStandardHeader | typeof zclFrames.ZCLMfgSpecificHeader;
-
-    /**
-     * Dispatch an incoming ZCL frame to the bound cluster and write the response. Handles the
-     * command-response rules: no reply to a Default Response or a group-addressed frame (ZCL 2.5.12.2),
-     * a Default Response carrying a thrown ZCLError's status, and `disableDefaultResponse`.
-     *
-     * Pass `meta.groupId` for a group-addressed frame, or the response suppression cannot be applied.
-     */
-    handleFrame(clusterId: number, frame: Buffer, meta?: { groupId?: number }): Promise<void>;
   }
-
-  /** @deprecated Use {@link Endpoint}; kept so existing references keep compiling. */
-  type ZCLNodeEndpoint = Endpoint;
 
   type ZCLDataType<Value> = import('@athombv/data-types').DataType<Value>;
   const ZCLDataTypes: ZCLDataTypes;

--- a/index.d.ts
+++ b/index.d.ts
@@ -2778,12 +2778,21 @@ declare module "zigbee-clusters" {
     getLogId(endpointId: number, clusterId: number): string;
   }
 
-  class ZCLNodeEndpoint extends EventEmitter {
-    constructor(node: ZCLNode, descriptor: {
+  /**
+   * Minimum shape an Endpoint needs from its owner. Endpoint only ever calls `sendFrame`, so a
+   * plain object is enough - a device serving bound clusters does not need a full ZCLNode, which
+   * models one remote peer and bakes that peer's address into its own `sendFrame`.
+   */
+  type EndpointInput = {
+    sendFrame(endpointId: number, clusterId: number, frame: Buffer): Promise<unknown>;
+  };
+
+  class Endpoint extends EventEmitter {
+    constructor(node: EndpointInput, descriptor: {
       endpointId: number;
       inputClusters: number[];
-      outputClusters: number[];
-    }[]);
+      outputClusters?: number[];
+    });
     // Typed lookup: known cluster names (per the generated `ClustersByName`)
     // resolve to their specific class (e.g. `clusters.onOff` is `OnOffCluster`),
     // while unknown keys fall back to the generic Cluster via the index half.
@@ -2795,7 +2804,19 @@ declare module "zigbee-clusters" {
     unbind(clusterName: string): void;
 
     makeDefaultResponseFrame(receivedFrame: unknown, success: boolean, status: types.ZCLEnum8Status): typeof zclFrames.ZCLStandardHeader | typeof zclFrames.ZCLMfgSpecificHeader;
+
+    /**
+     * Dispatch an incoming ZCL frame to the bound cluster and write the response. Handles the
+     * command-response rules: no reply to a Default Response or a group-addressed frame (ZCL 2.5.12.2),
+     * a Default Response carrying a thrown ZCLError's status, and `disableDefaultResponse`.
+     *
+     * Pass `meta.groupId` for a group-addressed frame, or the response suppression cannot be applied.
+     */
+    handleFrame(clusterId: number, frame: Buffer, meta?: { groupId?: number }): Promise<void>;
   }
+
+  /** @deprecated Use {@link Endpoint}; kept so existing references keep compiling. */
+  type ZCLNodeEndpoint = Endpoint;
 
   type ZCLDataType<Value> = import('@athombv/data-types').DataType<Value>;
   const ZCLDataTypes: ZCLDataTypes;

--- a/index.d.ts
+++ b/index.d.ts
@@ -2778,12 +2778,21 @@ declare module "zigbee-clusters" {
     getLogId(endpointId: number, clusterId: number): string;
   }
 
-  class ZCLNodeEndpoint extends EventEmitter {
-    constructor(node: ZCLNode, descriptor: {
+  /**
+   * Minimum shape an Endpoint needs from its owner. Endpoint only ever calls `sendFrame`, so a
+   * plain object is enough - a device serving bound clusters does not need a full ZCLNode, which
+   * models one remote peer and bakes that peer's address into its own `sendFrame`.
+   */
+  type EndpointInput = {
+    sendFrame(endpointId: number, clusterId: number, frame: Buffer): Promise<unknown>;
+  };
+
+  class Endpoint extends EventEmitter {
+    constructor(node: EndpointInput, descriptor: {
       endpointId: number;
       inputClusters: number[];
-      outputClusters: number[];
-    }[]);
+      outputClusters?: number[];
+    });
     // Typed lookup: known cluster names (per the generated `ClustersByName`)
     // resolve to their specific class (e.g. `clusters.onOff` is `OnOffCluster`),
     // while unknown keys fall back to the generic Cluster via the index half.
@@ -2795,7 +2804,20 @@ declare module "zigbee-clusters" {
     unbind(clusterName: string): void;
 
     makeDefaultResponseFrame(receivedFrame: unknown, success: boolean, status: types.ZCLEnum8Status): typeof zclFrames.ZCLStandardHeader | typeof zclFrames.ZCLMfgSpecificHeader;
+
+    /**
+     * Dispatch an incoming ZCL frame to the bound cluster and write the response. Handles the
+     * command-response rules: no reply to a Default Response or a group-addressed frame
+     * (ZCL 2.5.12.2), a Default Response carrying a thrown ZCLError's status, and
+     * `disableDefaultResponse`.
+     *
+     * Pass `meta.groupId` for a group-addressed frame, or the suppression cannot be applied.
+     */
+    handleFrame(clusterId: number, frame: Buffer, meta?: { groupId?: number }): Promise<void>;
   }
+
+  /** @deprecated Use {@link Endpoint}; kept so existing references keep compiling. */
+  type ZCLNodeEndpoint = Endpoint;
 
   type ZCLDataType<Value> = import('@athombv/data-types').DataType<Value>;
   const ZCLDataTypes: ZCLDataTypes;

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
 const _debug = require('debug');
 
 const ZCLNode = require('./lib/Node');
+const Endpoint = require('./lib/Endpoint');
 const Cluster = require('./lib/Cluster');
 const BoundCluster = require('./lib/BoundCluster');
 const zclTypes = require('./lib/zclTypes');
@@ -105,6 +106,7 @@ module.exports = {
 
   // ZCL
   ZCLNode,
+  Endpoint,
   zclTypes,
   zclFrames,
   ZCLDataTypes,

--- a/scripts/template.d.ts.txt
+++ b/scripts/template.d.ts.txt
@@ -53,12 +53,21 @@ declare module 'zigbee-clusters' {
     getLogId(endpointId: number, clusterId: number): string;
   }
 
-  class ZCLNodeEndpoint extends EventEmitter {
-    constructor(node: ZCLNode, descriptor: {
+  /**
+   * Minimum shape an Endpoint needs from its owner. Endpoint only ever calls `sendFrame`, so a
+   * plain object is enough - a device serving bound clusters does not need a full ZCLNode, which
+   * models one remote peer and bakes that peer's address into its own `sendFrame`.
+   */
+  type EndpointInput = {
+    sendFrame(endpointId: number, clusterId: number, frame: Buffer): Promise<unknown>;
+  };
+
+  class Endpoint extends EventEmitter {
+    constructor(node: EndpointInput, descriptor: {
       endpointId: number;
       inputClusters: number[];
-      outputClusters: number[];
-    }[]);
+      outputClusters?: number[];
+    });
     // Typed lookup: known cluster names (per the generated `ClustersByName`)
     // resolve to their specific class (e.g. `clusters.onOff` is `OnOffCluster`),
     // while unknown keys fall back to the generic Cluster via the index half.
@@ -70,7 +79,20 @@ declare module 'zigbee-clusters' {
     unbind(clusterName: string): void;
 
     makeDefaultResponseFrame(receivedFrame: unknown, success: boolean, status: types.ZCLEnum8Status): typeof zclFrames.ZCLStandardHeader | typeof zclFrames.ZCLMfgSpecificHeader;
+
+    /**
+     * Dispatch an incoming ZCL frame to the bound cluster and write the response. Handles the
+     * command-response rules: no reply to a Default Response or a group-addressed frame
+     * (ZCL 2.5.12.2), a Default Response carrying a thrown ZCLError's status, and
+     * `disableDefaultResponse`.
+     *
+     * Pass `meta.groupId` for a group-addressed frame, or the suppression cannot be applied.
+     */
+    handleFrame(clusterId: number, frame: Buffer, meta?: { groupId?: number }): Promise<void>;
   }
+
+  /** @deprecated Use {@link Endpoint}; kept so existing references keep compiling. */
+  type ZCLNodeEndpoint = Endpoint;
 
   type ZCLDataType<Value> = import('@athombv/data-types').DataType<Value>;
   const ZCLDataTypes: ZCLDataTypes;

--- a/test/endpointStandalone.js
+++ b/test/endpointStandalone.js
@@ -1,20 +1,11 @@
-// eslint-disable-next-line max-classes-per-file,lines-around-directive
 'use strict';
 
 const assert = require('assert');
 
-const { Endpoint, ZCLNode, BoundCluster } = require('..');
+const { Endpoint, BoundCluster } = require('..');
 
-const ENDPOINT_ID = 1;
 const BASIC_CLUSTER_ID = 0x0000;
 const MODEL_ID = 0x0005;
-const UNIMPLEMENTED_ID = 0x1234;
-
-const DESCRIPTOR = {
-  endpointId: ENDPOINT_ID,
-  inputClusters: [BASIC_CLUSTER_ID],
-  outputClusters: [],
-};
 
 class Basic extends BoundCluster {
 
@@ -24,78 +15,26 @@ class Basic extends BoundCluster {
 
 }
 
-/** A global Read Attributes request for the given attribute ids. */
-function readAttributes(ids, seq) {
-  const frame = Buffer.alloc(3 + ids.length * 2);
-  frame[0] = 0x00;
-  frame[1] = seq;
-  frame[2] = 0x00;
-  ids.forEach((id, i) => frame.writeUInt16LE(id, 3 + i * 2));
-  return frame;
-}
-
 describe('Endpoint standalone', function() {
-  /** Dispatch through an Endpoint owned by a plain object rather than a ZCLNode. */
-  async function viaEndpoint(frame, meta) {
+  it('serves bound clusters with nothing but a sendFrame owner', async function() {
+    // The whole point of the export: a device answering incoming commands is not a peer, so it
+    // should not have to construct a ZCLNode - which models one remote node and bakes that node's
+    // address into its own sendFrame. Endpoint touches its owner in exactly one place (sendFrame),
+    // so a plain object is enough. If that ever stops being true, this fails.
     let sent;
-    const endpoint = new Endpoint({
-      sendFrame: async (_ep, _cl, f) => {
-        sent = f;
+    const endpoint = new Endpoint(
+      {
+        sendFrame: async (_endpointId, _clusterId, frame) => {
+          sent = frame;
+        },
       },
-    }, DESCRIPTOR);
+      { endpointId: 1, inputClusters: [BASIC_CLUSTER_ID], outputClusters: [] },
+    );
     endpoint.bind('basic', new Basic());
-    await endpoint.handleFrame(BASIC_CLUSTER_ID, frame, meta);
-    return sent;
-  }
 
-  /** The same dispatch reached the long way, through a ZCLNode. */
-  async function viaNode(frame, meta) {
-    let sent;
-    const shim = {
-      endpointDescriptors: [DESCRIPTOR],
-      sendFrame: async (_ep, _cl, f) => {
-        sent = f;
-      },
-    };
-    const node = new ZCLNode(shim);
-    node.endpoints[ENDPOINT_ID].bind('basic', new Basic());
-    await shim.handleFrame(ENDPOINT_ID, BASIC_CLUSTER_ID, frame, meta);
-    return sent;
-  }
+    const request = Buffer.from([0x00, 0x07, 0x00, MODEL_ID, 0x00]);
+    await endpoint.handleFrame(BASIC_CLUSTER_ID, request);
 
-  it('needs nothing from its owner but sendFrame', async function() {
-    // The point of exporting Endpoint: a device serving bound clusters is not a peer, so it should
-    // not have to construct a ZCLNode - which exists to model one remote node and bakes that node's
-    // address into its own sendFrame.
-    const sent = await viaEndpoint(readAttributes([MODEL_ID], 7));
-
-    assert.ok(sent, 'a response should be sent');
     assert.equal(sent.toString('hex'), '180701050000420c486f6d657920427269646765');
-  });
-
-  it('dispatches identically to the same endpoint reached through a ZCLNode', async function() {
-    for (const [label, ids, seq, meta] of [
-      ['implemented', [MODEL_ID], 7, undefined],
-      ['unimplemented', [UNIMPLEMENTED_ID], 3, undefined],
-      ['mixed', [MODEL_ID, UNIMPLEMENTED_ID], 9, undefined],
-      ['group-addressed', [MODEL_ID], 1, { groupId: 0x1234 }],
-    ]) {
-      const frame = readAttributes(ids, seq);
-      const direct = await viaEndpoint(frame, meta);
-      const throughNode = await viaNode(frame, meta);
-      assert.deepEqual(direct, throughNode, label);
-    }
-  });
-
-  it('applies the group-addressed suppression itself', async function() {
-    // ZCL 2.5.12.2. This lives in Endpoint.handleFrame, so it comes along with the export rather
-    // than having to be reimplemented by whoever wires up a server.
-    const sent = await viaEndpoint(readAttributes([MODEL_ID], 1), { groupId: 0x1234 });
-    assert.equal(sent, undefined);
-  });
-
-  it('reports an unimplemented attribute as UNSUPPORTED_ATTRIBUTE', async function() {
-    const sent = await viaEndpoint(readAttributes([UNIMPLEMENTED_ID], 3));
-    assert.equal(sent[sent.length - 1], 0x86);
   });
 });

--- a/test/endpointStandalone.js
+++ b/test/endpointStandalone.js
@@ -1,0 +1,101 @@
+// eslint-disable-next-line max-classes-per-file,lines-around-directive
+'use strict';
+
+const assert = require('assert');
+
+const { Endpoint, ZCLNode, BoundCluster } = require('..');
+
+const ENDPOINT_ID = 1;
+const BASIC_CLUSTER_ID = 0x0000;
+const MODEL_ID = 0x0005;
+const UNIMPLEMENTED_ID = 0x1234;
+
+const DESCRIPTOR = {
+  endpointId: ENDPOINT_ID,
+  inputClusters: [BASIC_CLUSTER_ID],
+  outputClusters: [],
+};
+
+class Basic extends BoundCluster {
+
+  get modelId() {
+    return 'Homey Bridge';
+  }
+
+}
+
+/** A global Read Attributes request for the given attribute ids. */
+function readAttributes(ids, seq) {
+  const frame = Buffer.alloc(3 + ids.length * 2);
+  frame[0] = 0x00;
+  frame[1] = seq;
+  frame[2] = 0x00;
+  ids.forEach((id, i) => frame.writeUInt16LE(id, 3 + i * 2));
+  return frame;
+}
+
+describe('Endpoint standalone', function() {
+  /** Dispatch through an Endpoint owned by a plain object rather than a ZCLNode. */
+  async function viaEndpoint(frame, meta) {
+    let sent;
+    const endpoint = new Endpoint({
+      sendFrame: async (_ep, _cl, f) => {
+        sent = f;
+      },
+    }, DESCRIPTOR);
+    endpoint.bind('basic', new Basic());
+    await endpoint.handleFrame(BASIC_CLUSTER_ID, frame, meta);
+    return sent;
+  }
+
+  /** The same dispatch reached the long way, through a ZCLNode. */
+  async function viaNode(frame, meta) {
+    let sent;
+    const shim = {
+      endpointDescriptors: [DESCRIPTOR],
+      sendFrame: async (_ep, _cl, f) => {
+        sent = f;
+      },
+    };
+    const node = new ZCLNode(shim);
+    node.endpoints[ENDPOINT_ID].bind('basic', new Basic());
+    await shim.handleFrame(ENDPOINT_ID, BASIC_CLUSTER_ID, frame, meta);
+    return sent;
+  }
+
+  it('needs nothing from its owner but sendFrame', async function() {
+    // The point of exporting Endpoint: a device serving bound clusters is not a peer, so it should
+    // not have to construct a ZCLNode - which exists to model one remote node and bakes that node's
+    // address into its own sendFrame.
+    const sent = await viaEndpoint(readAttributes([MODEL_ID], 7));
+
+    assert.ok(sent, 'a response should be sent');
+    assert.equal(sent.toString('hex'), '180701050000420c486f6d657920427269646765');
+  });
+
+  it('dispatches identically to the same endpoint reached through a ZCLNode', async function() {
+    for (const [label, ids, seq, meta] of [
+      ['implemented', [MODEL_ID], 7, undefined],
+      ['unimplemented', [UNIMPLEMENTED_ID], 3, undefined],
+      ['mixed', [MODEL_ID, UNIMPLEMENTED_ID], 9, undefined],
+      ['group-addressed', [MODEL_ID], 1, { groupId: 0x1234 }],
+    ]) {
+      const frame = readAttributes(ids, seq);
+      const direct = await viaEndpoint(frame, meta);
+      const throughNode = await viaNode(frame, meta);
+      assert.deepEqual(direct, throughNode, label);
+    }
+  });
+
+  it('applies the group-addressed suppression itself', async function() {
+    // ZCL 2.5.12.2. This lives in Endpoint.handleFrame, so it comes along with the export rather
+    // than having to be reimplemented by whoever wires up a server.
+    const sent = await viaEndpoint(readAttributes([MODEL_ID], 1), { groupId: 0x1234 });
+    assert.equal(sent, undefined);
+  });
+
+  it('reports an unimplemented attribute as UNSUPPORTED_ATTRIBUTE', async function() {
+    const sent = await viaEndpoint(readAttributes([UNIMPLEMENTED_ID], 3));
+    assert.equal(sent[sent.length - 1], 0x86);
+  });
+});


### PR DESCRIPTION
A `ZCLNode` models **one remote node**: its constructor bakes that node's address into `sendFrame`, which is why `Endpoint.sendFrame` passes only `(endpointId, clusterId, frame)`. That is the right shape for talking *to* a device.

It is the wrong shape for *being* one. `BoundCluster` exists so incoming commands can be answered, and the dispatcher that makes that work all lives in `Endpoint.handleFrame`:

| | |
| --- | --- |
| 1 | parse the ZCL header |
| 2 | route to the binding or the cluster |
| 3 | no reply to a Default Response (`cmdId === 11`) |
| 4 | no reply to a group-addressed frame (ZCL 2.5.12.2) |
| 5 | turn a thrown `ZCLError` into a Default Response carrying its status |
| 6 | build the Default Response, or overlay the cluster-specific one |
| 7 | honour `disableDefaultResponse` |

`Endpoint` was not exported, so the only way in was to construct a `ZCLNode` purely as a shell to carry `sendFrame`, then throw it away. The alternative - `zclFrames` plus `BoundCluster` directly - means reimplementing 3 through 7 by hand, which is spec work that is easy to get subtly wrong.

## The change

One export. `Endpoint` needs nothing from its owner but `sendFrame` - a single call site, `lib/Endpoint.js:95` - so no code changed.

```js
const endpoint = new Endpoint({ sendFrame }, { endpointId, inputClusters: [0] });
endpoint.bind('basic', new MyBasicCluster());
await endpoint.handleFrame(clusterId, frame, meta);
```

## Types needed more than the export

They also needed to go in the right file. `index.d.ts` is **generated** from `scripts/template.d.ts.txt`; the declarations were hand-edited into the generated file first, and CI promptly regenerated it and reverted 25 of the 29 lines. They now live in the template and survive generation.

The existing `ZCLNodeEndpoint` declaration was not usable as written:

- **`handleFrame` was missing entirely** - the method this export exists for.
- **`descriptor` was declared as an array.** The constructor reads `descriptor.endpointId` and iterates `descriptor.inputClusters`, so it takes a single object. Anyone following the type would have written it wrong.
- **`outputClusters` was required**, though the constructor never reads it.
- The owner is now `EndpointInput` (`{ sendFrame }`) rather than `ZCLNode`, mirroring how `ZCLNodeInput` already widens the `ZCLNode` constructor.
- The class is named `Endpoint`, with `ZCLNodeEndpoint` kept as a deprecated alias so `ZCLNode.endpoints` keeps compiling.

Checked by type-checking a consumer against the regenerated declaration rather than only compiling the declaration itself - a plain `sendFrame` owner, a single descriptor object with `outputClusters` omitted, and `handleFrame` with and without `meta.groupId`, all under `--strict`.

## Validated before proposing it

Not a speculative export. It was tried in a real consumer first: a Zigbee router that serves a Basic cluster and today builds a throwaway `ZCLNode` for every incoming frame. Swapping it to a standalone `Endpoint` left its full suite green, including golden response frames recorded from live traffic, and the emitted bytes were identical in every case - group-addressed frames included, where the response must be suppressed.

That consumer change is not part of this PR; it waits on this export shipping.

## Tests

`test/endpointStandalone.js`, one case: that an `Endpoint` owned by a plain `{ sendFrame }` serves a bound cluster. It fails if the export is removed, which is the whole contract this PR adds.

It started as four. The other three were cut on review: comparing `Endpoint` against the same endpoint reached through a `ZCLNode` is near-tautological, since `Node.js:96` is literally `this.endpoints[endpointId].handleFrame(...)`; and the group-addressed suppression and the `0x86` status are library behaviour already covered by `test/testNode.js` and `test/boundClusterAttributeStatus.js`, not anything the export changes.

92 tests pass; `eslint .` is clean.