### PR TITLE
Add Time cluster attributes

### DIFF
--- a/lib/clusters/time.js
+++ b/lib/clusters/time.js
@@ -1,8 +1,22 @@
 'use strict';
 
 const Cluster = require('../Cluster');
+const { ZCLDataTypes } = require('../zclTypes');
 
 const ATTRIBUTES = {
+  time: { id: 0, type: ZCLDataTypes.UTC },
+  timeStatus: {
+    id: 1,
+    type: ZCLDataTypes.map8('master', 'synchronized', 'masterZoneDst', 'superseding'),
+  },
+  timeZone: { id: 2, type: ZCLDataTypes.int32 },
+  dstStart: { id: 3, type: ZCLDataTypes.uint32 },
+  dstEnd: { id: 4, type: ZCLDataTypes.uint32 },
+  dstShift: { id: 5, type: ZCLDataTypes.int32 },
+  standardTime: { id: 6, type: ZCLDataTypes.uint32 },
+  localTime: { id: 7, type: ZCLDataTypes.uint32 },
+  lastSetTime: { id: 8, type: ZCLDataTypes.UTC },
+  validUntilTime: { id: 8, type: ZCLDataTypes.UTC },
 };
 
 const COMMANDS = {};


### PR DESCRIPTION
Add Time cluster attributes.

Depends on https://github.com/athombv/node-data-types/pull/49 (UTC date type), and will need a bump in the package.json before this is merged.


