### PR TITLE
fix(time): Correct Time cluster attribute ids and unblock type generation

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -499,7 +499,18 @@ declare module "zigbee-clusters" {
       },
     ): Promise<void>;
   }
-  type TimeClusterAttributes = Record<never, never>;
+  type TimeClusterAttributes = {
+    time: { id: 0x00, type: ZCLDataType<number> },
+    timeStatus: { id: 0x01, type: ZCLDataType<Bitmap<"master" | "synchronized" | "masterZoneDst" | "superseding">> },
+    timeZone: { id: 0x02, type: ZCLDataType<number> },
+    dstStart: { id: 0x03, type: ZCLDataType<number> },
+    dstEnd: { id: 0x04, type: ZCLDataType<number> },
+    dstShift: { id: 0x05, type: ZCLDataType<number> },
+    standardTime: { id: 0x06, type: ZCLDataType<number> },
+    localTime: { id: 0x07, type: ZCLDataType<number> },
+    lastSetTime: { id: 0x08, type: ZCLDataType<number> },
+    validUntilTime: { id: 0x09, type: ZCLDataType<number> },
+  };
   type TimeClusterCommands = Record<never, never>;
   class TimeCluster<Attributes extends types.AttributeDefinitions = TimeClusterAttributes, Commands extends types.CommandDefinitions = TimeClusterCommands> extends Cluster<Attributes, Commands> {
   }

--- a/lib/clusters/time.js
+++ b/lib/clusters/time.js
@@ -5,10 +5,7 @@ const { ZCLDataTypes } = require('../zclTypes');
 
 const ATTRIBUTES = {
   time: { id: 0, type: ZCLDataTypes.UTC },
-  timeStatus: {
-    id: 1,
-    type: ZCLDataTypes.map8('master', 'synchronized', 'masterZoneDst', 'superseding'),
-  },
+  timeStatus: { id: 1, type: ZCLDataTypes.map8('master', 'synchronized', 'masterZoneDst', 'superseding') },
   timeZone: { id: 2, type: ZCLDataTypes.int32 },
   dstStart: { id: 3, type: ZCLDataTypes.uint32 },
   dstEnd: { id: 4, type: ZCLDataTypes.uint32 },
@@ -16,7 +13,7 @@ const ATTRIBUTES = {
   standardTime: { id: 6, type: ZCLDataTypes.uint32 },
   localTime: { id: 7, type: ZCLDataTypes.uint32 },
   lastSetTime: { id: 8, type: ZCLDataTypes.UTC },
-  validUntilTime: { id: 8, type: ZCLDataTypes.UTC },
+  validUntilTime: { id: 9, type: ZCLDataTypes.UTC },
 };
 
 const COMMANDS = {};

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "3.6.0",
       "license": "ISC",
       "dependencies": {
-        "@athombv/data-types": "^1.2.1",
+        "@athombv/data-types": "^1.3.0",
         "debug": "^4.1.1"
       },
       "devDependencies": {
@@ -29,13 +29,13 @@
         "watch": "^1.0.2"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=22"
       }
     },
     "node_modules/@athombv/data-types": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@athombv/data-types/-/data-types-1.2.1.tgz",
-      "integrity": "sha512-b6gAW70H12ua6q9TuVbfA0xz4cz5HLx09tpM0hh4sTZbjZmpeQKuqJ680WFA9HPWbkh8IC41Eny2rXcr5oA6Sg==",
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@athombv/data-types/-/data-types-1.3.0.tgz",
+      "integrity": "sha512-XJ7oMzKFcZdw2LpiBcr8QVmtQXkCpnOpDGpQ2iM2vuKjzosXQjAB0XUgKl+yubDNTFkTNa8mcFS5QdFP51O7pg==",
       "license": "GPL-3.0",
       "engines": {
         "node": ">=12.0.0"
@@ -6509,9 +6509,9 @@
   },
   "dependencies": {
     "@athombv/data-types": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/@athombv/data-types/-/data-types-1.2.1.tgz",
-      "integrity": "sha512-b6gAW70H12ua6q9TuVbfA0xz4cz5HLx09tpM0hh4sTZbjZmpeQKuqJ680WFA9HPWbkh8IC41Eny2rXcr5oA6Sg=="
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/@athombv/data-types/-/data-types-1.3.0.tgz",
+      "integrity": "sha512-XJ7oMzKFcZdw2LpiBcr8QVmtQXkCpnOpDGpQ2iM2vuKjzosXQjAB0XUgKl+yubDNTFkTNa8mcFS5QdFP51O7pg=="
     },
     "@athombv/jsdoc-template": {
       "version": "1.7.0",

--- a/package.json
+++ b/package.json
@@ -52,7 +52,7 @@
     "watch": "^1.0.2"
   },
   "dependencies": {
-    "@athombv/data-types": "^1.2.1",
+    "@athombv/data-types": "^1.3.0",
     "debug": "^4.1.1"
   }
 }

--- a/scripts/generate-types.mts
+++ b/scripts/generate-types.mts
@@ -474,6 +474,7 @@ function zclDataTypeToValueType(type: keyof typeof DataTypes): string {
     case "int32":
     case "int40":
     case "int48":
+    case "UTC":
       return "number";
     case "enum8":
     case "enum16":


### PR DESCRIPTION
Follow-up to #216.

- `validUntilTime` was id `0x0008`, same as `lastSetTime`. `attributesById` is keyed by id, so `0x0008` decoded as `validUntilTime` and `0x0009` was unknown. ZCL r8 table 3-69 puts it at `0x0009`.
- `generate-types` had no case for `UTC` and threw, so the workflow has failed on every master push since #216. Regenerated `index.d.ts` here.
- `@athombv/data-types` was pinned to `^1.2.1` in the lockfile, where `ZCLDataTypes.UTC` does not exist.